### PR TITLE
Remove tickboxes from PR-template to make task-circles on PR overview correct

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,13 +12,13 @@ _Fixes #(issue)_ (if the issue is on Github, simply link to it using the '#' sym
 - Documentation update
 - Anything else (provide your category)
 
-### Features:
+### Features: 
 - bulleted list of features, describing the code contributions in this pull request
 
 ### Questions: 
 - potential questions for the code reviewer (e.g., if you want feedback on a certain method or class; any feedback required from other code contributors with their mentioning)
 
-### Remarks:
+### Remarks: 
 - any additional remarks for the code reviewer
 - if your remarks or questions pertain to individual lines in the code, you may also include them as comments in the code review window
 


### PR DESCRIPTION
## Description

Small modification to the PR-template to remove:
- task tick boxes ([ ], [x]) 

Fixes the problem that Github interprets the task-tick-boxes as "open tasks" on a PR.

## Issue

The list with tick marks:

> ![Screen Shot 2022-07-19 at 12 46 08](https://user-images.githubusercontent.com/2803227/179805116-73ff4e3f-07da-401e-b59a-ee6abede85d9.png)

... leads to a label being added to the PR like this:

> ![Screen Shot 2022-07-19 at 12 46 58](https://user-images.githubusercontent.com/2803227/179805262-92d52259-163d-4ba4-88e7-667108d1fef3.png)

where the 1 completed task is the ticked box from the list and the 4 open tasks are the unticked items.

Ideally, this task "circle" should reflect real tasks which are still to be completed, as it does on the restructure modules PR #27:

> ![Screen Shot 2022-07-19 at 12 48 11](https://user-images.githubusercontent.com/2803227/179805532-228cbe2a-2d63-4e53-bf37-7c33ef28eb62.png)

... based on the task list in the PR description #27:

> ![Screen Shot 2022-07-19 at 12 50 00](https://user-images.githubusercontent.com/2803227/179805945-2f3591ae-ceaf-4715-815b-73cff6c036bc.png)

### Type of change:

- Documentation update
