### PR TITLE
Feat/darts primitives spec

### DIFF
--- a/aer/theorist/darts/model_search.py
+++ b/aer/theorist/darts/model_search.py
@@ -1,7 +1,7 @@
 import random
 import warnings
 from enum import Enum
-from typing import Callable, List, Tuple
+from typing import Callable, List, Sequence, Tuple
 
 import numpy as np
 import torch
@@ -48,16 +48,13 @@ class MixedOp(nn.Module):
     that is applied to an input variable.
     """
 
-    def __init__(self, primitives: List[str] = []):
+    def __init__(self, primitives: Sequence[str] = PRIMITIVES):
         """
         Initializes a mixture operation based on a pre-specified set of primitive operations.
 
         Arguments:
             primitives: list of primitives to be used in the mixture operation
         """
-        if not primitives:
-            primitives = PRIMITIVES
-
         super(MixedOp, self).__init__()
         self._ops = nn.ModuleList()
         # loop through all the 8 primitive operations
@@ -104,7 +101,10 @@ class Cell(nn.Module):
     """
 
     def __init__(
-        self, steps: int = 2, n_input_states: int = 1, primitives: List[str] = []
+        self,
+        steps: int = 2,
+        n_input_states: int = 1,
+        primitives: Sequence[str] = PRIMITIVES,
     ):
         """
         Initializes a cell based on the number of hidden nodes (steps)
@@ -215,7 +215,7 @@ class Network(nn.Module):
         architecture_fixed: bool = False,
         classifier_weight_decay: float = 0,
         darts_type: DARTS_Type = DARTS_Type.ORIGINAL,
-        primitives: List[str] = [],
+        primitives: Sequence[str] = PRIMITIVES,
     ):
         """
         Initializes the network.
@@ -240,11 +240,7 @@ class Network(nn.Module):
         self._multiplier = (
             1  # the number of internal nodes that get concatenated to the output
         )
-
-        if not primitives:
-            self.primitives = PRIMITIVES
-        else:
-            self.primitives = primitives
+        self.primitives = primitives
 
         # set parameters
         self._dim_output = self._steps

--- a/aer/theorist/darts/operations.py
+++ b/aer/theorist/darts/operations.py
@@ -379,7 +379,7 @@ OPS = {
 
 # this is the list of primitives actually used,
 # and it should be a set of names contained in the OPS dictionary
-PRIMITIVES = [
+PRIMITIVES = (
     "none",
     "add",
     "subtract",
@@ -387,7 +387,7 @@ PRIMITIVES = [
     "lin_sigmoid",
     "mult",
     "lin_relu",
-]
+)
 
 # make sure that every primitive is in the OPS dictionary
 for name in PRIMITIVES:

--- a/aer/theorist/theorist_darts.py
+++ b/aer/theorist/theorist_darts.py
@@ -29,7 +29,12 @@ class Theorist_DARTS(Theorist, ABC):
 
     _lr_plot_name = "Learning Rates"
 
-    def __init__(self, study_name, darts_type=DARTS_Type.ORIGINAL):
+    def __init__(
+        self,
+        study_name,
+        darts_type=DARTS_Type.ORIGINAL,
+        primitives=PRIMITIVES,
+    ):
         super(Theorist_DARTS, self).__init__(study_name)
 
         self.DARTS_type = darts_type
@@ -50,6 +55,8 @@ class Theorist_DARTS(Theorist, ABC):
 
         self.model_search_epochs = darts_cfg.epochs
         self.eval_epochs = darts_cfg.eval_epochs
+
+        self.primitives = primitives
 
         if self.DARTS_type == DARTS_Type.ORIGINAL:
             self.theorist_name = "original_darts"
@@ -242,6 +249,7 @@ class Theorist_DARTS(Theorist, ABC):
             steps=best_num_graph_nodes,
             n_input_states=object_of_study.__get_input_dim__(),
             darts_type=self.DARTS_type,
+            primitives=self.primitives,
         )
         utils.load(model, model_path)
         alphas_normal = torch.load(arch_path)
@@ -411,6 +419,7 @@ class Theorist_DARTS(Theorist, ABC):
                 n_input_states=object_of_study.__get_input_dim__(),
                 classifier_weight_decay=darts_cfg.classifier_weight_decay,
                 darts_type=self.DARTS_type,
+                primitives=self.primitives,
             )
             if darts_cfg.eval_custom_initialization:
                 self._eval_model.apply(init_weights)
@@ -558,7 +567,9 @@ class Theorist_DARTS(Theorist, ABC):
         self._eval_num_params_log.append(num_params)
         num_non_zero_edges = self._eval_model.alphas_normal.data.shape[0] - int(
             np.sum(
-                self._eval_model.alphas_normal.data[:, PRIMITIVES.index("none")].numpy()
+                self._eval_model.alphas_normal.data[
+                    :, self.primitives.index("none")
+                ].numpy()
             )
         )
         self._eval_num_edges_log.append(num_non_zero_edges)
@@ -644,6 +655,7 @@ class Theorist_DARTS(Theorist, ABC):
             n_input_states=object_of_study.__get_input_dim__(),
             classifier_weight_decay=darts_cfg.classifier_weight_decay,
             darts_type=self.DARTS_type,
+            primitives=self.primitives,
         )
 
         # initialize model
@@ -709,7 +721,7 @@ class Theorist_DARTS(Theorist, ABC):
         self.num_arch_ops = self.model.alphas_normal.data.shape[
             1
         ]  # number of operations
-        self.arch_ops_labels = PRIMITIVES  # operations
+        self.arch_ops_labels = self.primitives  # operations
         self.train_error_log = np.empty(
             (self.model_search_epochs, 1)
         )  # log training error
@@ -1370,6 +1382,7 @@ class Theorist_DARTS(Theorist, ABC):
                         n_input_states=object_of_study.__get_input_dim__(),
                         classifier_weight_decay=darts_cfg.classifier_weight_decay,
                         darts_type=self.DARTS_type,
+                        primitives=self.primitives,
                     )
                     if darts_cfg.eval_custom_initialization:
                         new_model.apply(init_weights)

--- a/example/weber/run_weber_study.py
+++ b/example/weber/run_weber_study.py
@@ -106,7 +106,9 @@ experimentalist_validation = Experimentalist_Popper(
 # THEORIST
 
 # initialize theorist
-theorist = Theorist_DARTS(study_name, darts_type=DARTS_Type.ORIGINAL)
+theorist = Theorist_DARTS(
+    study_name, darts_type=DARTS_Type.ORIGINAL, primitives=["none", "add", "subtract"]
+)
 
 # specify plots
 plots = list()


### PR DESCRIPTION
## Description

This PR adds user functionality to specify the set of primitives (space of operations) for DARTS. So far, all primitives are pulled from operations.py which may not be as apparent to the user. With the added feature, users can specify the set of primitives in the initialization of the DARTS model.

### Type of change:
- New feature (non-breaking change which adds functionality)

### Features: 
- added primitives as argument to NNmodel, Cell and MixedOpp so that user can specify primitives when initializing NNmodel
- by default, the default primitives are used.

### Remarks: 
- Note that whenever the same NN model is (re-)instantiated, it would have to use the same set of primitives.
