### PR TITLE
sklearn & split ObjectOfStudy PR 2: gather functions in aer.theorist.darts

### DIFF
--- a/aer/theorist/darts/utils.py
+++ b/aer/theorist/darts/utils.py
@@ -6,7 +6,7 @@ import typing
 
 import numpy as np
 import torch
-import torch.nn as nn
+from torch import nn as nn
 
 from aer.theorist.darts.model_search import Network
 from aer.variable import ValueType
@@ -467,3 +467,11 @@ def get_best_fitting_models(
     topk_BICs_names = res[1]
 
     return (topk_losses_names, topk_BICs_names)
+
+
+def format_input_target(input, target, criterion):
+
+    if isinstance(criterion, nn.CrossEntropyLoss):
+        target = target.squeeze()
+
+    return (input, target)

--- a/aer/theorist/theorist_darts.py
+++ b/aer/theorist/theorist_darts.py
@@ -18,6 +18,7 @@ import aer.theorist.darts.visualize as viz
 from aer.theorist.darts.architect import Architect
 from aer.theorist.darts.model_search import DARTSType, Network
 from aer.theorist.darts.operations import PRIMITIVES
+from aer.theorist.darts.utils import format_input_target
 from aer.theorist.theorist import Theorist
 from aer.utils import Plot_Types
 from aer.variable import ValueType as output_types
@@ -1523,14 +1524,6 @@ def model_formatted(model, input, object_of_study):
     output = model(input)
     output_formatted = m(output)
     return output_formatted
-
-
-def format_input_target(input, target, criterion):
-
-    if isinstance(criterion, nn.CrossEntropyLoss):
-        target = target.squeeze()
-
-    return (input, target)
 
 
 # trains model for one architecture epoch


### PR DESCRIPTION
## Description

Move `format_input_target` to `aer.theorist.darts.utils` from `aer.theorist.theorist_darts`. This is the last dependency we need from the "old theorist" in order to run DARTS with the scikit-learn wrapper without any recourse to the `DARTS_Theorist`.

### Type of change:
*Delete as appropriate:*
- Refactoring (change which cleans up the code without changing its functionality)
