### PR TITLE
sklearn & split ObjectOfStudy PR 4: split a simpler `darts_model_plot` function from the `darts.visualize.plot` function

### DIFF
--- a/aer/theorist/darts/visualize.py
+++ b/aer/theorist/darts/visualize.py
@@ -112,7 +112,7 @@ def darts_model_plot(
     start = 0
     for i in range(steps):
         end = start + n
-        print(start, end)
+        _logger.debug(start, end)
         # for k in [2*i, 2*i + 1]:
         for k in range(
             start, end


### PR DESCRIPTION
## Description

Extract the core logic from the `darts.visualize.plot` into a separate, simpler function, which just returns a `dot.Graph`. The caller can then handle displaying or saving the graph. Needed for plotting the DARTS computation graphs in Jupyter.

### Type of change:
- New feature (non-breaking change which adds functionality)

### [Optional] Screenshots:
Allows displays like this in Jupyter:
![Screen Shot 2022-08-02 at 10 40 26](https://user-images.githubusercontent.com/2803227/182866216-d1e2ecc7-3c4f-4c55-8c2e-20e4533d018c.png)

