### PR TITLE
MyPy: ignore imports in __init__.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
         args:
         - "--max-line-length=100"
         - "--extend-ignore=E203"
+        - "--per-file-ignores=__init__.py:F401"
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v0.960"  # 2020.10.21
     hooks:


### PR DESCRIPTION
## Description

Ignore whether imports in `__init__.py` files are used. This avoids the workaround of adding `# noqa: F401` to imports in `__init__.py` files.


### Example before the change
```python
# aer/__init__.py
from . import config
```

`flake8` reports an error:
```
% pre-commit run --files=aer/__init__.py
...
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

aer/__init__.py:1:1: F401 '.config' imported but unused
...
```

### After the change
```
% pre-commit run --files=aer/__init__.py
...
flake8...................................................................Passed
...
```

### Type of change:
- Linting update

### Features: 
- added additional parameter to flake8 config

