### PR TITLE
Set PyCharm docstring format to Google

### DIFF
--- a/.idea/AER.iml
+++ b/.idea/AER.iml
@@ -16,7 +16,7 @@
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">
-    <option name="format" value="PLAIN" />
-    <option name="myDocStringFormat" value="Plain" />
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
   </component>
 </module>


### PR DESCRIPTION
## Description

Match the Docstring format defined in our Readme with the PyCharm IDE configuration.

### Type of change:
- Documentation update
