### PR TITLE
Closed-Loop Run Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,3 @@ dmypy.json
 
 # Material for MkDocs
 site/
-
-# Pycharm IDE files 
-.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/autora.iml
+++ b/.idea/autora.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Poetry (autora) (2)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+</module>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,16 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="3.9" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyMissingOrEmptyDocstringInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (autora) (2)" project-jdk-type="Python SDK" />
+  <component name="PythonCompatibilityInspectionAdvertiser">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/autora.iml" filepath="$PROJECT_DIR$/.idea/autora.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PySciProjectComponent">
+    <option name="PY_SCI_VIEW_SUGGESTED" value="true" />
+  </component>
+</project>

--- a/.idea/poetry.xml
+++ b/.idea/poetry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PoetryConfigService">
+    <option name="poetryVirtualenvPaths">
+      <set>
+        <option value="$USER_HOME$/Library/Caches/pypoetry/virtualenvs/autora-17yK3Jyq-py3.8/bin/python" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/tests/test_closed_loop.py
+++ b/tests/test_closed_loop.py
@@ -1,0 +1,81 @@
+"""
+Test the closed-loop state-machine with run function implementation.
+
+"""
+
+import numpy as np
+import pytest  # noqa: 401
+
+from autora.cycle import DataSetCollection, RunCollection, TheoryCollection, run
+from autora.variable import Variable, VariableCollection
+
+
+# Define basic versions of the modules
+def dummy_theorist(data, metadata, search_space):
+    def theory(x):
+        return x + 1
+
+    return theory
+
+
+def dummy_experimentalist(data, metadata: VariableCollection, theory, n_samples=10):
+    low = metadata.independent_variables[0].min
+    high = metadata.independent_variables[0].max
+    x_prime = np.random.uniform(low, high, n_samples)
+    return x_prime
+
+
+def dummy_experiment_runner(x_prime):
+    return x_prime + 1
+
+
+def test_run_function():
+    """
+    This is a prototype closed-loop cycle using the "transitions" package as a state-machine
+    handler.
+    """
+
+    #  Define parameters for run
+    # Assuming start from experiment runner we create dummy x' values
+    x1 = np.linspace(0, 1, 10)  # Seed x' to input into the experiment runner
+    # metadata are value constraints for the experimentalist
+    metadata = VariableCollection(
+        independent_variables=[Variable(name="x1", value_range=(-5, 5))],
+        dependent_variables=[Variable(name="y", value_range=(-10, 10))],
+    )
+    parameters = RunCollection(
+        metadata=metadata,
+        search_space=None,
+        data=DataSetCollection([]),
+        cycle_count=0,
+        theories=TheoryCollection([]),
+        independent_variable_values=x1,
+        max_cycle_count=4,
+        first_state="experiment runner",
+    )
+
+    results = run(
+        theorist=dummy_theorist,
+        experimentalist=dummy_experimentalist,
+        experiment_runner=dummy_experiment_runner,
+        run_container=parameters,
+        graph=True,
+    )
+
+    assert results.data.datasets.__len__() == results.max_cycle_count, (
+        f"Number of datasets generated ({results.data.datasets.__len__()}) "
+        f"should equal the max number of cycles ({results.max_cycle_count})."
+    )
+
+    assert results.theories.theories.__len__() == results.max_cycle_count, (
+        f"Number of theories generated ({results.theories.theories.__len__()}) "
+        f"should equal the max number of cycles ({results.max_cycle_count})."
+    )
+
+    # Other check ideas
+    # Start point checks - need a set-up function
+
+
+if __name__ == "__main__":
+    test_run_function()
+    print("end")

--- a/tests/test_closed_loop.py
+++ b/tests/test_closed_loop.py
@@ -6,7 +6,7 @@ Test the closed-loop state-machine with run function implementation.
 import numpy as np
 import pytest  # noqa: 401
 
-from autora.cycle import AERCycle, plot_state_diagram, run
+from autora.cycle import AERCycle
 from autora.variable import Variable, VariableCollection
 
 
@@ -29,7 +29,7 @@ def dummy_experiment_runner(x_prime):
     return x_prime.x + 1
 
 
-def test_run_function():
+def test_run():
     """
     This is a prototype closed-loop cycle using the "transitions" package as a state-machine
     handler.
@@ -44,18 +44,20 @@ def test_run_function():
         dependent_variables=[Variable(name="y", value_range=(-10, 10))],
     )
 
-    # Run the closed-loop cycle
-    results = run(
+    cycle = AERCycle(
         theorist=dummy_theorist,
         experimentalist=dummy_experimentalist,
         experiment_runner=dummy_experiment_runner,
         metadata=metadata,
         first_state="experiment runner",
         independent_variable_values=x1,
+        add_graphing=True,
     )
+    cycle.run()
+    results = cycle.results
 
-    # Plot a state diagram of the cycle model
-    plot_state_diagram(AERCycle())
+    # Plot diagram, will remove this functionality in production
+    cycle.get_graph().draw("state_machine_diagram.png", prog="dot")
 
     assert results.data.datasets.__len__() == results.max_cycle_count, (
         f"Number of datasets generated ({results.data.datasets.__len__()}) "
@@ -72,5 +74,5 @@ def test_run_function():
 
 
 if __name__ == "__main__":
-    test_run_function()
+    test_run()
     print("end")

--- a/tests/test_closed_loop.py
+++ b/tests/test_closed_loop.py
@@ -6,7 +6,7 @@ Test the closed-loop state-machine with run function implementation.
 import numpy as np
 import pytest  # noqa: 401
 
-from autora.cycle import run
+from autora.cycle import AERCycle, plot_state_diagram, run
 from autora.variable import Variable, VariableCollection
 
 
@@ -44,6 +44,7 @@ def test_run_function():
         dependent_variables=[Variable(name="y", value_range=(-10, 10))],
     )
 
+    # Run the closed-loop cycle
     results = run(
         theorist=dummy_theorist,
         experimentalist=dummy_experimentalist,
@@ -52,6 +53,9 @@ def test_run_function():
         first_state="experiment runner",
         independent_variable_values=x1,
     )
+
+    # Plot a state diagram of the cycle model
+    plot_state_diagram(AERCycle())
 
     assert results.data.datasets.__len__() == results.max_cycle_count, (
         f"Number of datasets generated ({results.data.datasets.__len__()}) "

--- a/tests/test_closed_loop.py
+++ b/tests/test_closed_loop.py
@@ -6,7 +6,7 @@ Test the closed-loop state-machine with run function implementation.
 import numpy as np
 import pytest  # noqa: 401
 
-from autora.cycle import DataSetCollection, RunCollection, TheoryCollection, run
+from autora.cycle import run
 from autora.variable import Variable, VariableCollection
 
 
@@ -26,7 +26,7 @@ def dummy_experimentalist(data, metadata: VariableCollection, theory, n_samples=
 
 
 def dummy_experiment_runner(x_prime):
-    return x_prime + 1
+    return x_prime.x + 1
 
 
 def test_run_function():
@@ -43,23 +43,14 @@ def test_run_function():
         independent_variables=[Variable(name="x1", value_range=(-5, 5))],
         dependent_variables=[Variable(name="y", value_range=(-10, 10))],
     )
-    parameters = RunCollection(
-        metadata=metadata,
-        search_space=None,
-        data=DataSetCollection([]),
-        cycle_count=0,
-        theories=TheoryCollection([]),
-        independent_variable_values=x1,
-        max_cycle_count=4,
-        first_state="experiment runner",
-    )
 
     results = run(
         theorist=dummy_theorist,
         experimentalist=dummy_experimentalist,
         experiment_runner=dummy_experiment_runner,
-        run_container=parameters,
-        graph=True,
+        metadata=metadata,
+        first_state="experiment runner",
+        independent_variable_values=x1,
     )
 
     assert results.data.datasets.__len__() == results.max_cycle_count, (

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -3,11 +3,11 @@ import numpy as np
 import pytest  # noqa: 401
 
 from autora.cycle import (  # noqa: 401
+    AERModule,
     DataSetCollection,
+    RunCollection,
+    TheoryCollection,
     run,
-    start_experiment_runner,
-    start_experimentalist,
-    start_theorist,
 )
 from autora.variable import Variable, VariableCollection
 
@@ -62,31 +62,34 @@ def test_cycle():
         independent_variables=[Variable(name="x1", value_range=(-5, 5))],
         dependent_variables=[Variable(name="y", value_range=(-10, 10))],
     )
+
     parameters = dict(
-        theorist=dummy_theorist,
-        experimentalist=dummy_experimentalist,
-        experiment_runner=dummy_experiment_runner,
         metadata=metadata,
         search_space=None,
         data=DataSetCollection([]),
-        cycle_count=0,
-        theory=None,
+        theories=TheoryCollection([lambda x: x + 2]),
         independent_variable_values=x1,
         max_cycle_count=10,
+        cycle_count=0,
+        theorist=dummy_theorist,
+        experimentalist=dummy_experimentalist,
+        experiment_runner=dummy_experiment_runner,
     )
 
     # Run from experiment runner
     experiment_runner_results_run = run(
-        starting_point="experiment_runner", **parameters
+        first_state=AERModule.EXPERIMENT_RUNNER, **parameters
     )
     print(experiment_runner_results_run)
 
     # Run starting from theorist
-    theorist_results_run = run(starting_point="theorist", **parameters)
+    theorist_results_run = run(first_state=AERModule.THEORIST, **parameters)
     print(theorist_results_run)
 
     # Run starting from experimentalist
-    experimentalist_results_run = run(starting_point="experimentalist", **parameters)
+    experimentalist_results_run = run(
+        first_state=AERModule.EXPERIMENTALIST, **parameters
+    )
     print(experimentalist_results_run)
 
 


### PR DESCRIPTION
## Description
Refactored the state machine to not use a run function. The run is now a method of the cycle class and during initialization all parameters are passed as keywords. 

### Type of change:
- New feature (non-breaking change which adds functionality)

### Features: 
- Run function for closed-loop cycle
- New container classes: TheoryCollection, RunCollection. These classes hold parameters and aggregate products from the AER cycle. 
- Enum class for key modules 

### Remarks: 
- I left in state machine graphing functionality with a switch in the state machine initialization. I know we discussed removing the graphing functionality but I figured it could be useful while things are still under development. We can always remove for production.  

### Questions: 
- One annoying thing about the transitions package is that it makes encapsulating methods (making them private) difficult. In the cycle object we create many methods that are run upon entering and exiting states. These are called in externally by the transitions package so they need to be public or we have to refer to them as `_AERCycle<__privateMethod__>` in our state and transition definitions. I tested this for the `_end_statement` method (defined on line 318) with the 'on_enter' the "end" state defined on line 366. `State(name="end", on_enter=["_AERCycle__end_statement"])` It's ugly but it works. Curious on your thoughts. 