### PR TITLE
Exploration: closed loop with darts random experimentalist

### DIFF
--- a/autora/cycle/__init__.py
+++ b/autora/cycle/__init__.py
@@ -138,7 +138,7 @@ class ExperimentRunner(Protocol):
         ...
 
 
-class AERModule(Enum):
+class AERModule(str, Enum):
     THEORIST = "theorist"
     EXPERIMENTALIST = "experimentalist"
     EXPERIMENT_RUNNER = "experiment runner"

--- a/autora/cycle/__init__.py
+++ b/autora/cycle/__init__.py
@@ -40,6 +40,9 @@ class DataSet:
 class DataSetCollection:
     datasets: List[DataSet]
 
+    def __getitem__(self, item):
+        return self.datasets[item]
+
 
 def combine_datasets(a: Union[DataSetCollection, DataSet], b: DataSet):
     if isinstance(a, DataSet):

--- a/autora/cycle/__init__.py
+++ b/autora/cycle/__init__.py
@@ -67,6 +67,9 @@ class Theory(Protocol):
 class TheoryCollection:
     theories: List[Theory]
 
+    def __getitem__(self, item):
+        return self.theories[item]
+
 
 def combine_theories(a: Union[TheoryCollection, Theory], b: Theory):
     if callable(a):

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -168,14 +168,9 @@ def test_sklearn_theorist():
         theorist=scikit_learn_regressor_theorist_wrapper(
             DARTSRegressor(
                 num_graph_nodes=2,
-                max_epochs=1000,
-                primitives=(
-                    "none",
-                    "add",
-                    "subtract",
-                    "linear",
-                    "relu",
-                ),
+                param_updates_per_epoch=1,
+                max_epochs=100,
+                primitives=("none", "linear", "add", "subtract"),
             )
         ),
         experimentalist=make_random_experimentalist(n_observations_per_experiment=50),
@@ -191,14 +186,21 @@ def test_sklearn_theorist():
         cycle_count=0,
     )
     print(experimentalist_results_run)
+
+    fig = plt.figure()
+
+    # Plot the experimental results
+    for data in experimentalist_results_run.data.datasets:
+        if data is not None:
+            plt.scatter(data.x, data.y)
+
+    # Plot the fitted theory
     x_test = np.linspace(
         metadata.independent_variables[0].min,
         metadata.independent_variables[0].max,
         100,
     ).reshape(-1, 1)
-    fig = plt.figure()
-    for data in experimentalist_results_run.data.datasets:
-        if data is not None:
-            plt.scatter(data.x, data.y)
     plt.plot(x_test, experimentalist_results_run.theories[-1](x_test), c="orange")
+
+    # Show the results
     fig.show()

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
+import copy
+from functools import partial
+
 import numpy as np
 import pytest  # noqa: 401
+from matplotlib import pyplot as plt
+from sklearn.base import BaseEstimator as SklearnBaseEstimator
 
-from autora.cycle import (  # noqa: 401
-    AERModule,
-    DataSetCollection,
-    RunCollection,
-    TheoryCollection,
-    run,
-)
+from autora.cycle import AERModule, DataSetCollection, TheoryCollection, run
+from autora.skl.darts import DARTSRegressor
 from autora.variable import Variable, VariableCollection
 
 
@@ -93,5 +93,112 @@ def test_cycle():
     print(experimentalist_results_run)
 
 
-if __name__ == "__main__":
-    test_cycle()
+def test_sklearn_theorist():
+    """
+    This test prototypes the design and calling of the closed cycle system using a SciKit-Learn
+    regressor as the theorist.
+
+    theorist: Generates a constant theory of  y = x + 1, independent of inputs.
+    experimentalist: Generates new independent variables (x') to experiment from a uniform random
+                     selection of values from a defined range. Independent of inputs.
+    experiment_runner: Simulates data gained from an experiment that perfectly matches the theory
+                       y = x' + 1
+
+    This test was first conceptualized from the exercise of starting from the experiment runner.
+    Seed x' (Independent variable) values are inputs to experiment runner to start the cycle and
+    create syntheticexperimental data.
+
+    Notes on seed requirements:
+    1. Experiment Runner Start
+        a. Independent variable values
+    2. Theorist Start
+        a. Paired independent variable values and dependent variable values
+    3. Experimentalist Start
+        a. Theory
+        b. Paired independent variable values and dependent variable values
+
+    """
+
+    def scikit_learn_regressor_theorist_wrapper(theorist: SklearnBaseEstimator):
+        def theorist_(data, metadata, search_space):
+            theorist_ = copy.copy(theorist)
+            X = np.vstack([d.x.reshape(-1, 1) for d in data.datasets if d is not None])
+            y = np.vstack([d.y.reshape(-1, 1) for d in data.datasets if d is not None])
+            theorist_.fit(X, y)
+            theory = theorist_.predict
+            return theory
+
+        return theorist_
+
+    def make_random_experimentalist(n_observations_per_experiment=10):
+        def dummy_experimentalist(data, metadata: VariableCollection, theory):
+            low = metadata.independent_variables[0].min
+            high = metadata.independent_variables[0].max
+            x_prime = np.random.uniform(low, high, n_observations_per_experiment)
+            return x_prime
+
+        return dummy_experimentalist
+
+    def x_plus_one(x):
+        return x + 1
+
+    random_number_generator = np.random.default_rng(seed=42)
+    noise_generator = partial(random_number_generator.normal, loc=0.0, scale=0.5)
+
+    def instantiated_noise_source(x):
+        x_noisy = x + noise_generator(size=x.shape)
+        return x_noisy
+
+    def make_synthetic_experiment_runner(ground_truth_theory, noise_source):
+        def synthetic_experiment_runner(x_prime):
+            measurement = noise_source(ground_truth_theory(x_prime))
+            return measurement
+
+        return synthetic_experiment_runner
+
+    #  Define parameters for run
+    metadata = VariableCollection(
+        independent_variables=[Variable(name="x1", value_range=(-5, 5))],
+        dependent_variables=[Variable(name="y", value_range=(-10, 10))],
+    )
+
+    # Run starting from experimentalist
+    experimentalist_results_run = run(
+        first_state=AERModule.EXPERIMENTALIST,
+        theorist=scikit_learn_regressor_theorist_wrapper(
+            DARTSRegressor(
+                num_graph_nodes=2,
+                max_epochs=1000,
+                primitives=(
+                    "none",
+                    "add",
+                    "subtract",
+                    "linear",
+                    "relu",
+                ),
+            )
+        ),
+        experimentalist=make_random_experimentalist(n_observations_per_experiment=50),
+        experiment_runner=make_synthetic_experiment_runner(
+            x_plus_one, noise_source=instantiated_noise_source
+        ),
+        metadata=metadata,
+        search_space=None,
+        data=DataSetCollection([None]),
+        theories=TheoryCollection([None]),
+        independent_variable_values=None,
+        max_cycle_count=10,
+        cycle_count=0,
+    )
+    print(experimentalist_results_run)
+    x_test = np.linspace(
+        metadata.independent_variables[0].min,
+        metadata.independent_variables[0].max,
+        100,
+    ).reshape(-1, 1)
+    fig = plt.figure()
+    for data in experimentalist_results_run.data.datasets:
+        if data is not None:
+            plt.scatter(data.x, data.y)
+    plt.plot(x_test, experimentalist_results_run.theories[-1](x_test), c="orange")
+    fig.show()


### PR DESCRIPTION
## Description

Get the closed-loop cycle working with the DARTS theorist and a random experimenter. The example code is in the `tests/test_cycle.py` file in the function `test_sklearn_theorist`, and will be moved to a notebook file later.

The screenshot shows the setup code (left), initializing the `run` function along with the Theorist, random experimenter, and experimentalist (with a noise source to make it more realistic). On the right is the result of the run, with the data from each "experiment cycle" shown in a different color, and the theorist's fit in orange. 
> **Caveat:** I've tuned the parameters so that DARTS actually fits properly, it's still extremely unstable and most of the fits were completely off. I don't think that's a problem with the cycle though, more a problem with DARTS.

<img width="2036" alt="Screen Shot 2022-10-12 at 08 59 17" src="https://user-images.githubusercontent.com/2803227/195349079-b896edd1-06b8-4e51-8846-f12548ec9af4.png">

The important parts are:
- Initialize the cycle
```python
    experimentalist_results_run = run(
```
- Specify where the cycle begins – here with the "experimentalist" as we have neither data nor a list of samples to make
```python
        first_state=AERModule.EXPERIMENTALIST,
```
- Specify the theorist. Here we have a function which wraps the DARTSRegressor and gives it the right interface for our cycler. In place of the DARTSRegressor, we could use any scikit-learn compatible regressor.
```python
        theorist=scikit_learn_regressor_theorist_wrapper(
            DARTSRegressor(
                num_graph_nodes=2,
                param_updates_per_epoch=1,
                max_epochs=100,
                primitives=("none", "linear", "add", "subtract"),
            )
        ),
```
- Specify the experimentalist. We have a simple function which samples random points between the minimum and maximum of the independent variables.
```python
        experimentalist=make_random_experimentalist(n_observations_per_experiment=50),
```
- Specify the experiment runner. We give it a "ground truth function" (here "x_plus_one") and also include a function which adds Gaussian noise, though this could also be any other noise distribution we could imagine and code
```python
        experiment_runner=make_synthetic_experiment_runner(
            x_plus_one, noise_source=instantiated_noise_source
        ),
```
- Specify the bounds
```python
        metadata=VariableCollection(
        independent_variables=[Variable(name="x1", value_range=(-5, 5))],
        dependent_variables=[Variable(name="y", value_range=(-10, 10))],
    ),
```
- Initialize the rest of the run function. Much of this can be replaced by defaults later.
```python
        search_space=None,
        data=DataSetCollection([None]),
        theories=TheoryCollection([None]),
        independent_variable_values=None,
        max_cycle_count=10,
        cycle_count=0,
    )
```

Implements #120
Implements #121 

### Type of change:
- New feature (non-breaking change which adds functionality)

### Questions
- How do we like the interface?