### PR TITLE
Fix pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,5 +23,6 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-requests]
+        language_version: python3.8
 default_language_version:
   python: python3


### PR DESCRIPTION
## Description

Fix two problems with the pre-commit hooks:
- the location of the flake8 repository has moved from gitlab to github
- the mypy doesn't explicitly set the python version number, so it's unclear which version we're targeting

### Type of change:
- Bug fix (non-breaking change which fixes an issue)
