### PR TITLE
docs: update link to scikit-learn object in dissimilarity sampler doc…

### DIFF
--- a/autora/experimentalist/sampler/dissimilarity.py
+++ b/autora/experimentalist/sampler/dissimilarity.py
@@ -39,11 +39,11 @@ def summed_dissimilarity_sampler(
         X: pool of IV conditions to evaluate dissimilarity
         X_ref: reference pool of IV conditions
         n: number of samples to select
-        metric: dissimilarity measure. Options: 'euclidean', 'manhattan', 'chebyshev',
+        metric (str): dissimilarity measure. Options: 'euclidean', 'manhattan', 'chebyshev',
             'minkowski', 'wminkowski', 'seuclidean', 'mahalanobis', 'haversine',
             'hamming', 'canberra', 'braycurtis', 'matching', 'jaccard', 'dice',
             'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener',
-            'sokalsneath', 'yule'. See `sklearn.metrics.DistanceMetric` for more details.
+            'sokalsneath', 'yule'. See [sklearn.metrics.DistanceMetric][] for more details.
 
     Returns:
         Sampled pool

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ site_name: Autonomous Empirical Research
 theme:
   name: material
 
+watch:
+  - autora/
+
 plugins:
   - search
   - gen-files:
@@ -14,8 +17,11 @@ plugins:
         nav_file: SUMMARY.md
   - section-index
   - mkdocstrings:
-      watch:
-        - autora/
+      handlers:
+        python:
+          import:
+            - https://scikit-learn.org/stable/objects.inv
+
 
 markdown_extensions:
   - pymdownx.arithmatex:


### PR DESCRIPTION
## Description

add a working link to the scikit-learn documentation `sklearn.metrics.DistanceMetric` in the dissimilarity sampler docstring.

### Type of change:
- Documentation update

### Features: 
- Added ability to link to sklearn objects natively in our documentation.

### [Optional] Screenshots:

<img width="726" alt="Screen Shot 2022-12-08 at 10 18 46" src="https://user-images.githubusercontent.com/2803227/206484043-f3dfa12f-1cad-4c26-9def-147b7fdb5480.png">
