### PR TITLE
set variable range default to none so that it doesn't conflict with allowed values

### DIFF
--- a/autora/variable/__init__.py
+++ b/autora/variable/__init__.py
@@ -21,7 +21,7 @@ class Variable:
     """Describes an experimental variable: name, type, range, units, and value of a variable."""
 
     name: str = ""
-    value_range: Optional[Tuple[Any, Any]] = (0, 1)
+    value_range: Optional[Tuple[Any, Any]] = None
     allowed_values: Optional[Sequence] = None
     units: str = ""
     type: ValueType = ValueType.REAL


### PR DESCRIPTION


## Description

Set variable range default to none so that it doesn't conflict with allowed values.

_Fixes #185(issue)_ 

### Type of change:
- Bug fix (non-breaking change which fixes an issue)

