### PR TITLE
ci: get cacheing working on GitHub workflow pytest

### DIFF
--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -24,5 +24,5 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: "poetry"
-    - run: poetry install --with test
+    - run: poetry install
     - run: poetry run pytest

--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - run: pipx install poetry
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: "poetry"
+    - run: pipx install poetry
     - run: poetry install --with test
     - run: poetry run pytest

--- a/.github/workflows/py.test.yml
+++ b/.github/workflows/py.test.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
+    - run: pipx install poetry
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: "poetry"
-    - run: pipx install poetry
     - run: poetry install --with test
     - run: poetry run pytest


### PR DESCRIPTION
... to speed up CI checks

### Type of change:
- Testing update

Now successfully uses the cache:
<img width="767" alt="Screen Shot 2022-12-13 at 13 21 45" src="https://user-images.githubusercontent.com/2803227/207414211-f85bf86b-7985-4ace-87ae-aa4d62f5f89a.png">
