### PR TITLE
Feat/parallel pipe

### DIFF
--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Optional,
     Protocol,
     Sequence,
@@ -345,6 +346,7 @@ def _parse_params_to_nested_dict(params_dict: Dict, divider: str):
 def make_pipeline(
     steps: Optional[Sequence[Union[Pool, Pipe]]] = None,
     params: Optional[Dict[str, Any]] = None,
+    kind: Literal["serial", "parallel"] = "serial",
 ) -> Pipeline:
     """
     A factory function to make pipeline objects.
@@ -439,7 +441,13 @@ def make_pipeline(
         ('step_1', functools.partial(<function divisor_filter at 0x...>, divisor=3))], \
         params={})
 
+        It is possible to create parallel pipelines too:
+        >>> pl = make_pipeline([range(5), range(10,15)], kind="parallel")
+        >>> pl
+        ParallelPipeline(steps=[('step_0', range(0, 5)), ('step_1', range(10, 15))], params={})
 
+        >>> list(pl.run())
+        [0, 1, 2, 3, 4, 10, 11, 12, 13, 14]
 
     """
 
@@ -462,7 +470,12 @@ def make_pipeline(
 
         steps_.append((name_in_pipeline, pipe))
 
-    pipeline = Pipeline(steps_, params=params)
+    if kind == "serial":
+        pipeline = Pipeline(steps_, params=params)
+    elif kind == "parallel":
+        pipeline = ParallelPipeline(steps_, params=params)
+    else:
+        raise NotImplementedError(f"{kind=} is not implemented")
 
     return pipeline
 

--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -127,11 +127,7 @@ class Pipeline:
         """Successively pass the input values through the Pipe."""
 
         # Initialize the parameters objects.
-        pipeline_params = _parse_params_to_nested_dict(
-            self.params, divider=PARAM_DIVIDER
-        )
-        call_params = _parse_params_to_nested_dict(params, divider=PARAM_DIVIDER)
-        merged_params = _merge_dicts(pipeline_params, call_params)
+        merged_params = self._merge_params_with_self_params(params)
 
         try:
             # Check we have steps to use
@@ -173,6 +169,14 @@ class Pipeline:
             results.append(pipe(results[-1], **all_params_for_pipe))
 
         return results[-1]
+
+    def _merge_params_with_self_params(self, params):
+        pipeline_params = _parse_params_to_nested_dict(
+            self.params, divider=PARAM_DIVIDER
+        )
+        call_params = _parse_params_to_nested_dict(params, divider=PARAM_DIVIDER)
+        merged_params = _merge_dicts(pipeline_params, call_params)
+        return merged_params
 
     run = __call__
 

--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -279,16 +279,16 @@ class PipelineUnion(Pipeline):
         # Initialize the parameters objects.
         merged_params = self._merge_params_with_self_params(params)
 
-        parallel_results = []
+        results = []
 
         # Run the parallel steps over the input
         for name, pipe in self.steps:
             all_params_for_step = merged_params.get(name, dict())
             if ex is None:
                 if isinstance(pipe, Pool):
-                    parallel_results.append(pipe(**all_params_for_step))
+                    results.append(pipe(**all_params_for_step))
                 elif isinstance(pipe, Iterable):
-                    parallel_results.append(pipe)
+                    results.append(pipe)
                 else:
                     raise NotImplementedError(
                         f"{pipe=} cannot be used in the PipelineUnion"
@@ -297,11 +297,11 @@ class PipelineUnion(Pipeline):
                 assert isinstance(
                     pipe, Pipe
                 ), f"{pipe=} is incompatible with the Pipe interface"
-                parallel_results.append(pipe(ex, **all_params_for_step))
+                results.append(pipe(ex, **all_params_for_step))
 
-        concatenated_results = chain.from_iterable(parallel_results)
+        union_results = chain.from_iterable(results)
 
-        return concatenated_results
+        return union_results
 
     run = __call__
 

--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -411,7 +411,7 @@ class ParallelPipeline(Pipeline):
     Run several Pipes in parallel and concatenate all their results.
 
     Examples:
-        You can use the ParallelPipeline to parallelize a series of poolers:
+        You can use the ParallelPipeline to parallelize a group of poolers:
         >>> parallel_pipeline_0 = ParallelPipeline([
         ...      ("pool_1", make_pipeline([range(5)])),
         ...      ("pool_2", make_pipeline([range(25, 30)])),
@@ -427,6 +427,18 @@ class ParallelPipeline(Pipeline):
         ... )
         >>> list(parallel_pipeline_1.run())
         [0, 1, 2, 3, 4, 25, 26, 27, 28, 29]
+
+        You can use the ParallelPipeline to parallelize a group of pipes – each of which gets
+        the same input.
+        >>> pipeline_with_embedded_parallel = Pipeline([
+        ...      ("pool", range(22)),
+        ...      ("filters",  ParallelPipeline([
+        ...          ("div_5_filter", lambda x: filter(lambda i: i % 5 == 0, x)),
+        ...          ("div_7_filter", lambda x: filter(lambda i: i % 7 == 0, x))
+        ...         ]))
+        ... ])
+        >>> list(pipeline_with_embedded_parallel.run())
+        [0, 5, 10, 15, 20, 0, 7, 14, 21]
 
     """
 

--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -233,38 +233,38 @@ def _merge_dicts(a: dict, b: dict):
     return a_
 
 
-class ParallelPipeline(Pipeline):
+class PipelineUnion(Pipeline):
     """
     Run several Pipes in parallel and concatenate all their results.
 
     Examples:
         You can use the ParallelPipeline to parallelize a group of poolers:
-        >>> parallel_pipeline_0 = ParallelPipeline([
+        >>> union_pipeline_0 = PipelineUnion([
         ...      ("pool_1", make_pipeline([range(5)])),
         ...      ("pool_2", make_pipeline([range(25, 30)])),
         ...     ]
         ... )
-        >>> list(parallel_pipeline_0.run())
+        >>> list(union_pipeline_0.run())
         [0, 1, 2, 3, 4, 25, 26, 27, 28, 29]
 
-        >>> parallel_pipeline_1 = ParallelPipeline([
+        >>> union_pipeline_1 = PipelineUnion([
         ...      ("pool_1", range(5)),
         ...      ("pool_2", range(25, 30)),
         ...     ]
         ... )
-        >>> list(parallel_pipeline_1.run())
+        >>> list(union_pipeline_1.run())
         [0, 1, 2, 3, 4, 25, 26, 27, 28, 29]
 
         You can use the ParallelPipeline to parallelize a group of pipes – each of which gets
         the same input.
-        >>> pipeline_with_embedded_parallel = Pipeline([
+        >>> pipeline_with_embedded_union = Pipeline([
         ...      ("pool", range(22)),
-        ...      ("filters",  ParallelPipeline([
+        ...      ("filters",  PipelineUnion([
         ...          ("div_5_filter", lambda x: filter(lambda i: i % 5 == 0, x)),
         ...          ("div_7_filter", lambda x: filter(lambda i: i % 7 == 0, x))
         ...         ]))
         ... ])
-        >>> list(pipeline_with_embedded_parallel.run())
+        >>> list(pipeline_with_embedded_union.run())
         [0, 5, 10, 15, 20, 0, 7, 14, 21]
 
     """
@@ -291,7 +291,7 @@ class ParallelPipeline(Pipeline):
                     parallel_results.append(pipe)
                 else:
                     raise NotImplementedError(
-                        f"{pipe=} cannot be used in the ParallelPipeline"
+                        f"{pipe=} cannot be used in the PipelineUnion"
                     )
             else:
                 assert isinstance(
@@ -447,7 +447,7 @@ def make_pipeline(
         It is possible to create parallel pipelines too:
         >>> pl = make_pipeline([range(5), range(10,15)], kind="union")
         >>> pl
-        ParallelPipeline(steps=[('step_0', range(0, 5)), ('step_1', range(10, 15))], params={})
+        PipelineUnion(steps=[('step_0', range(0, 5)), ('step_1', range(10, 15))], params={})
 
         >>> list(pl.run())
         [0, 1, 2, 3, 4, 10, 11, 12, 13, 14]
@@ -476,7 +476,7 @@ def make_pipeline(
     if kind == "serial":
         pipeline = Pipeline(steps_, params=params)
     elif kind == "union":
-        pipeline = ParallelPipeline(steps_, params=params)
+        pipeline = PipelineUnion(steps_, params=params)
     else:
         raise NotImplementedError(f"{kind=} is not implemented")
 

--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -357,6 +357,9 @@ def make_pipeline(
     Args:
         steps: a sequence of Pipe-compatible objects
         params: a dictionary of parameters passed to each Pipe by its inferred name
+        kind: whether the steps should run in "serial", passing data from one to the next,
+            or in "union", where all the steps get the same data and the output is the union
+            of all the results.
 
     Returns:
         A pipeline object

--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -346,7 +346,7 @@ def _parse_params_to_nested_dict(params_dict: Dict, divider: str):
 def make_pipeline(
     steps: Optional[Sequence[Union[Pool, Pipe]]] = None,
     params: Optional[Dict[str, Any]] = None,
-    kind: Literal["serial", "parallel"] = "serial",
+    kind: Literal["serial", "union"] = "serial",
 ) -> Pipeline:
     """
     A factory function to make pipeline objects.
@@ -442,7 +442,7 @@ def make_pipeline(
         params={})
 
         It is possible to create parallel pipelines too:
-        >>> pl = make_pipeline([range(5), range(10,15)], kind="parallel")
+        >>> pl = make_pipeline([range(5), range(10,15)], kind="union")
         >>> pl
         ParallelPipeline(steps=[('step_0', range(0, 5)), ('step_1', range(10, 15))], params={})
 
@@ -472,7 +472,7 @@ def make_pipeline(
 
     if kind == "serial":
         pipeline = Pipeline(steps_, params=params)
-    elif kind == "parallel":
+    elif kind == "union":
         pipeline = ParallelPipeline(steps_, params=params)
     else:
         raise NotImplementedError(f"{kind=} is not implemented")

--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -462,8 +462,14 @@ class ParallelPipeline(Pipeline):
                     parallel_results.append(pipe(**all_params_for_step))
                 elif isinstance(pipe, Iterable):
                     parallel_results.append(pipe)
+                else:
+                    raise NotImplementedError(
+                        f"{pipe=} cannot be used in the ParallelPipeline"
+                    )
             else:
-                assert isinstance(pipe, Pipe)
+                assert isinstance(
+                    pipe, Pipe
+                ), f"{pipe=} is incompatible with the Pipe interface"
                 parallel_results.append(pipe(ex, **all_params_for_step))
 
         concatenated_results = chain.from_iterable(parallel_results)

--- a/autora/experimentalist/pipeline.py
+++ b/autora/experimentalist/pipeline.py
@@ -117,7 +117,7 @@ class Pipeline:
         self.params = params
 
     def __repr__(self):
-        return f"Pipeline(steps={self.steps}, params={self.params})"
+        return f"{self.__class__.__name__}(steps={self.steps}, params={self.params})"
 
     def __call__(
         self,

--- a/tests/test_experimentalist_pipeline.py
+++ b/tests/test_experimentalist_pipeline.py
@@ -331,3 +331,20 @@ def test_params_parser_recurse():
             "measure": "least_confident",
         },
     }
+
+
+##############################################################################
+# Parallel Pipelines
+##############################################################################
+
+
+def test_parallelpipeline_run():
+    pl = make_pipeline([range(3), range(10, 13)], kind="parallel")
+    assert list(pl.run()) == [0, 1, 2, 10, 11, 12]
+
+
+def test_parallelpipeline_many_steps():
+    pl = make_pipeline([range(0, 5) for _ in range(1000)], kind="parallel")
+    results = list(pl.run())
+    assert len(results) == 5000
+    assert results[0:10] == [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]

--- a/tests/test_experimentalist_pipeline.py
+++ b/tests/test_experimentalist_pipeline.py
@@ -339,12 +339,12 @@ def test_params_parser_recurse():
 
 
 def test_parallelpipeline_run():
-    pl = make_pipeline([range(3), range(10, 13)], kind="parallel")
+    pl = make_pipeline([range(3), range(10, 13)], kind="union")
     assert list(pl.run()) == [0, 1, 2, 10, 11, 12]
 
 
 def test_parallelpipeline_many_steps():
-    pl = make_pipeline([range(0, 5) for _ in range(1000)], kind="parallel")
+    pl = make_pipeline([range(0, 5) for _ in range(1000)], kind="union")
     results = list(pl.run())
     assert len(results) == 5000
     assert results[0:10] == [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]


### PR DESCRIPTION
# Description

Add a ParallelPipeline object which passes the input to all the pipes independently and then concatenates the result.### 

# Type of change:
- New feature (non-breaking change which adds functionality)

# History

Suggested by @chadcwilliams and @younesStrittmatter:
> I [Younes] just chatted with Chad about the experimentalist, and he came up with a really great idea: As far as I understand, the experimentalist pipeline works like a bottleneck? So the output of a sampler gets fed into the following sampler, and so on. But it would be great to also "add" experimental conditions back in. For example, one could use the difference sampler, add conditions from the uncertainty sampler, and then randomly sample from the combined conditions. That way, instead of only being able to "sequentially" sample, we were able to sample "parallel". On a different note: Is it possible to use Pipelines in Pipelines? So one could build two different Sampler-Pipelines, parallelize them by "adding", and then build a Filter-Pipeline, that filters from them again. This would make the Pipeline very flexible. Maybe I am mistaken, and this is already possible, but if not, it might be worth thinking about implementing it.