### PR TITLE
209 deepcopy theorist

### DIFF
--- a/autora/cycle/simple.py
+++ b/autora/cycle/simple.py
@@ -471,6 +471,8 @@ class SimpleCycle:
             data_in.metadata.independent_variables
         )  # The number of independent variables
         x, y = all_observations[:, :n_xs], all_observations[:, n_xs:]
+        if y.shape[1] == 1:
+            y = y.ravel()
         new_theorist = copy.deepcopy(theorist)
         new_theorist.fit(x, y)
         data_out = replace(

--- a/autora/cycle/simple.py
+++ b/autora/cycle/simple.py
@@ -471,7 +471,7 @@ class SimpleCycle:
             data_in.metadata.independent_variables
         )  # The number of independent variables
         x, y = all_observations[:, :n_xs], all_observations[:, n_xs:]
-        new_theorist = copy.copy(theorist)
+        new_theorist = copy.deepcopy(theorist)
         new_theorist.fit(x, y)
         data_out = replace(
             data_in,

--- a/tests/test_sklearn_pipeline.py
+++ b/tests/test_sklearn_pipeline.py
@@ -1,0 +1,56 @@
+import numpy as np
+import sklearn.pipeline as skp
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+
+from autora.cycle import Cycle
+from autora.experimentalist.pipeline import Pipeline
+from autora.experimentalist.sampler import random_sampler
+from autora.variable import Variable, VariableCollection
+
+
+def test_skpipe_theory_copy():
+    """Checks that a deep copy is performed. When the autora.Cycle is copying the theorist."""
+
+    X = np.linspace(0, 1, 10)
+
+    # Variable Metadata
+    study_metadata = VariableCollection(
+        independent_variables=[
+            Variable(name="x", units="cm", allowed_values=np.linspace(0, 1, 100)),
+        ],
+        dependent_variables=[Variable(name="class", allowed_values=[0, 1])],
+    )
+
+    # Theorist with skl Pipeline
+    clf = skp.Pipeline([("scaler", StandardScaler()), ("lr", LogisticRegression())])
+
+    # Experimentalist
+    experimentalist = Pipeline(
+        [
+            ("pool", X),
+            ("sampler", random_sampler),
+        ],
+        params={
+            "sampler": {"n": 15},
+        },
+    )
+
+    # Experiment Runner
+    def experiment_runner(xs):
+        y_return = np.where(xs > 0.5, 1, 0)
+        return y_return
+
+    cycle = Cycle(
+        metadata=study_metadata,
+        theorist=clf,
+        experimentalist=experimentalist,
+        experiment_runner=experiment_runner,
+    )
+    cycle.run(6)
+
+    # Check that the memory space of all estimators are different
+    l_memory = [id(s["lr"]) for s in cycle.data.theories]
+    n_unique = len(np.unique(l_memory))
+    n_theories = len(cycle.data.theories)
+    assert n_unique == n_theories

--- a/tests/test_sklearn_pipeline.py
+++ b/tests/test_sklearn_pipeline.py
@@ -10,7 +10,7 @@ from autora.variable import Variable, VariableCollection
 
 
 def test_skpipe_theory_copy():
-    """Checks that a deep copy is performed. When the autora.Cycle is copying the theorist."""
+    """Checks that a deep copy is performed when the autora.Cycle is copying the theorist."""
 
     X = np.linspace(0, 1, 10)
 


### PR DESCRIPTION
## Description

Fixes the issue #209 where past theories were being overwritten each cycle when using sklearn's Pipeline to construct a Theorist with preprocessing. 


### Type of change:
- Bug fix (non-breaking change which fixes an issue)

### Features: 
- Changed to use a `deepcopy` instead of `copy` in the simple cycle when copying the Theorist. 
- Added a test file to ensure the memory space of each Theorist's estimators are unique when using sklearn's Pipeline as a theorist.

