### PR TITLE
fix: update deprecated use of np.float

### DIFF
--- a/autora/theorist/bms/parallel.py
+++ b/autora/theorist/bms/parallel.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from random import randint, random
 from typing import Optional, Tuple
 
-import numpy as np
 from numpy import exp
 
 from .mcmc import Tree

--- a/autora/theorist/bms/parallel.py
+++ b/autora/theorist/bms/parallel.py
@@ -117,7 +117,7 @@ class Parallel:
         BT1, BT2 = t1.BT, t2.BT
         EB1, EB2 = t1.EB, t2.EB
         # The energy change
-        DeltaE = np.float(EB1) * (1.0 / BT2 - 1.0 / BT1) + np.float(EB2) * (
+        DeltaE = float(EB1) * (1.0 / BT2 - 1.0 / BT1) + float(EB2) * (
             1.0 / BT1 - 1.0 / BT2
         )
         if DeltaE > 0:


### PR DESCRIPTION
## Description

replace `np.float` with `float`

_Fixes #221_

Required for #213 

### Type of change:
- Bug fix (non-breaking change which fixes an issue)