### PR TITLE
Refactor cycle plot tests

### DIFF
--- a/tests/test_cycle_plots.py
+++ b/tests/test_cycle_plots.py
@@ -21,7 +21,7 @@ from autora.variable import Variable, VariableCollection
 
 
 @pytest.fixture
-def ground_truth_1d():
+def ground_truth_1x():
     def ground_truth(xs):
         return xs + 1.0
 
@@ -29,7 +29,7 @@ def ground_truth_1d():
 
 
 @pytest.fixture
-def cycle_lr(ground_truth_1d):
+def cycle_lr(ground_truth_1x):
     random.seed(1)
 
     # Variable Metadata
@@ -61,7 +61,7 @@ def cycle_lr(ground_truth_1d):
         rng = np.random.default_rng(seed=180)
 
         def runner(xs):
-            return ground_truth_1d(xs) + rng.normal(0, 0.1, xs.shape)
+            return ground_truth_1x(xs) + rng.normal(0, 0.1, xs.shape)
 
         return runner
 
@@ -82,7 +82,7 @@ def cycle_lr(ground_truth_1d):
 
 
 @pytest.fixture
-def ground_truth_2d():
+def ground_truth_2x():
     def ground_truth(X):
         return X[:, 0] + (0.5 * X[:, 1]) + 1.0
 
@@ -90,7 +90,7 @@ def ground_truth_2d():
 
 
 @pytest.fixture
-def cycle_multi_lr(ground_truth_2d):
+def cycle_multi_lr(ground_truth_2x):
     random.seed(1)
 
     # def ground_truth(X):
@@ -126,7 +126,7 @@ def cycle_multi_lr(ground_truth_2d):
         rng = np.random.default_rng(seed=180)
 
         def runner(xs):
-            return ground_truth_2d(xs) + rng.normal(0, 0.25, xs.shape[0])
+            return ground_truth_2x(xs) + rng.normal(0, 0.25, xs.shape[0])
 
         return runner
 
@@ -248,11 +248,11 @@ def test_3d_plot(cycle_multi_lr):
     )
 
 
-def test_score_functions(cycle_lr, ground_truth_1d):
+def test_score_functions(cycle_lr, ground_truth_1x):
     X_test = cycle_lr.data.metadata.independent_variables[0].allowed_values.reshape(
         -1, 1
     )
-    y_test = ground_truth_1d(X_test)
+    y_test = ground_truth_1x(X_test)
 
     scores_default = cycle_default_score(cycle_lr, X_test, y_test)
     scores_specified = cycle_specified_score(r2_score, cycle_lr, X_test, y_test)
@@ -277,11 +277,11 @@ def test_score_functions(cycle_lr, ground_truth_1d):
     assert np.array_equal(scores_default, scores_specified)
 
 
-def test_cycle_score_plot(cycle_lr, ground_truth_1d):
+def test_cycle_score_plot(cycle_lr, ground_truth_1x):
     X_test = cycle_lr.data.metadata.independent_variables[0].allowed_values.reshape(
         -1, 1
     )
-    y_test = ground_truth_1d(X_test)
+    y_test = ground_truth_1x(X_test)
     fig = plot_cycle_score(cycle_lr, X_test, y_test)
 
     # Should have 1 axis
@@ -308,12 +308,12 @@ def test_cycle_score_plot(cycle_lr, ground_truth_1d):
     assert np.array_equal(np.around(y_plotted, 8), np.around(y_values, 8))
 
 
-def test_cycle_score_plot_multi_lr(cycle_multi_lr, ground_truth_2d):
+def test_cycle_score_plot_multi_lr(cycle_multi_lr, ground_truth_2x):
     cycle_multi_lr.run(12)
     X_test = np.array(
         list(grid_pool(cycle_multi_lr.data.metadata.independent_variables))
     )
-    y_test = ground_truth_2d(X_test)
+    y_test = ground_truth_2x(X_test)
     fig = plot_cycle_score(cycle_multi_lr, X_test, y_test)
 
     # Test line is plotted correctly

--- a/tests/test_cycle_plots.py
+++ b/tests/test_cycle_plots.py
@@ -75,6 +75,9 @@ def cycle_lr(ground_truth_1d):
         experiment_runner=example_synthetic_experiment_runner,
     )
 
+    # Run 10 iterations
+    cycle.run(10)
+
     return cycle
 
 
@@ -163,21 +166,20 @@ def test_2d_plot(cycle_lr):
     """
     Tests the 2d plotting functionality of plot_results_panel.
     """
-    cycle_lr.run(8)
     steps = 51
     fig = plot_results_panel_2d(
         cycle_lr, steps=steps, wrap=3, subplot_kw={"sharex": True, "sharey": True}
     )
 
-    # Should have 9 axes, 8 with data and the last turned off
-    assert len(fig.axes) == 9
-    assert sum([s.axison for s in fig.axes]) == 8
+    # Should have 12 axes, 10 with data and the last 2 turned off
+    assert len(fig.axes) == 12
+    assert sum([s.axison for s in fig.axes]) == 10
 
     # Check number of data points on each figure
     # Blue dots should start at 0 and augment by 5.
     # Orange should always be 5-this is the condition sampling rate set by the Experimentalist.
     l_counts = []
-    for axes in fig.axes[:-1]:
+    for axes in fig.axes[:-2]:
         blue_dots = (
             len(axes.collections[0].get_offsets().mask)
             - axes.collections[0].get_offsets().mask.any(axis=1).sum()
@@ -190,12 +192,23 @@ def test_2d_plot(cycle_lr):
     assert np.array_equal(
         np.array(l_counts),
         np.array(
-            [[0, 5], [5, 5], [10, 5], [15, 5], [20, 5], [25, 5], [30, 5], [35, 5]]
+            [
+                [0, 5],
+                [5, 5],
+                [10, 5],
+                [15, 5],
+                [20, 5],
+                [25, 5],
+                [30, 5],
+                [35, 5],
+                [40, 5],
+                [45, 5],
+            ]
         ),
     )
 
     # Test theory line is being plotted
-    for axes in fig.axes[:-1]:
+    for axes in fig.axes[:-2]:
         assert len(axes.lines[0].get_xdata()) == steps
         assert len(axes.lines[0].get_ydata()) == steps
 
@@ -236,7 +249,6 @@ def test_3d_plot(cycle_multi_lr):
 
 
 def test_score_functions(cycle_lr, ground_truth_1d):
-    cycle_lr.run(10)
     X_test = cycle_lr.data.metadata.independent_variables[0].allowed_values.reshape(
         -1, 1
     )
@@ -266,7 +278,6 @@ def test_score_functions(cycle_lr, ground_truth_1d):
 
 
 def test_cycle_score_plot(cycle_lr, ground_truth_1d):
-    cycle_lr.run(20)
     X_test = cycle_lr.data.metadata.independent_variables[0].allowed_values.reshape(
         -1, 1
     )
@@ -278,7 +289,7 @@ def test_cycle_score_plot(cycle_lr, ground_truth_1d):
 
     # Test line is plotted correctly
     axis = fig.axes[0]
-    assert len(axis.lines[0].get_xdata()) == 20
+    assert len(axis.lines[0].get_xdata()) == 10
     y_values = np.array(
         [
             0.98950589,
@@ -291,16 +302,6 @@ def test_cycle_score_plot(cycle_lr, ground_truth_1d):
             0.9848339,
             0.99359794,
             0.99691326,
-            0.99547573,
-            0.995913,
-            0.99711678,
-            0.99841886,
-            0.99737463,
-            0.9972299,
-            0.99772379,
-            0.99838647,
-            0.99853528,
-            0.99798914,
         ]
     )
     y_plotted = axis.lines[0].get_ydata()
@@ -342,9 +343,6 @@ def test_2d_plot_indexing(cycle_lr):
     """
     Tests the 2d plotting functionality of plot_results_panel.
     """
-    # l_test = list(np.arange(100))
-
-    cycle_lr.run(8)
     steps = 51
     fig = plot_results_panel_2d(
         cycle_lr,
@@ -363,7 +361,6 @@ def test_2d_plot_slicing(cycle_lr):
     """
     Tests the 2d plotting functionality of plot_results_panel.
     """
-    cycle_lr.run(10)
     steps = 51
 
     # Using Slice function

--- a/tests/test_cycle_plots.py
+++ b/tests/test_cycle_plots.py
@@ -167,7 +167,7 @@ def test_check_replace_default_kw():
 
 def test_2d_plot(cycle_lr):
     """
-    Tests the 2d plotting functionality of plot_results_panel.
+    Tests plotting functionality of plot_results_panel_2d.
     """
     steps = 51
     fig = plot_results_panel_2d(
@@ -217,6 +217,9 @@ def test_2d_plot(cycle_lr):
 
 
 def test_3d_plot(cycle_multi_lr):
+    """
+    Tests plotting functionality of plot_results_panel_3d.
+    """
     steps = 20
     fig = plot_results_panel_3d(
         cycle_multi_lr,
@@ -251,6 +254,9 @@ def test_3d_plot(cycle_multi_lr):
 
 
 def test_score_functions(cycle_lr, ground_truth_1x):
+    """
+    Tests the scoring functions cycle_default_score and cycle_specified_score.
+    """
     X_test = cycle_lr.data.metadata.independent_variables[0].allowed_values.reshape(
         -1, 1
     )
@@ -280,6 +286,9 @@ def test_score_functions(cycle_lr, ground_truth_1x):
 
 
 def test_cycle_score_plot(cycle_lr, ground_truth_1x):
+    """
+    Tests plotting functionality of test_cycle_score_plot with a 2D linear regression.
+    """
     X_test = cycle_lr.data.metadata.independent_variables[0].allowed_values.reshape(
         -1, 1
     )
@@ -311,6 +320,9 @@ def test_cycle_score_plot(cycle_lr, ground_truth_1x):
 
 
 def test_cycle_score_plot_multi_lr(cycle_multi_lr, ground_truth_2x):
+    """
+    Tests plotting functionality of test_cycle_score_plot with multiple linear regression cycle.
+    """
     cycle_multi_lr.run(6)  # Run additional 6 times, total of 12 cycles
     X_test = np.array(
         list(grid_pool(cycle_multi_lr.data.metadata.independent_variables))
@@ -343,7 +355,7 @@ def test_cycle_score_plot_multi_lr(cycle_multi_lr, ground_truth_2x):
 
 def test_2d_plot_indexing(cycle_lr):
     """
-    Tests the 2d plotting functionality of plot_results_panel.
+    Test indexing of 2d plotter.
     """
     steps = 51
     fig = plot_results_panel_2d(

--- a/tests/test_cycle_plots.py
+++ b/tests/test_cycle_plots.py
@@ -361,7 +361,7 @@ def test_2d_plot_indexing(cycle_lr):
 
 def test_2d_plot_slicing(cycle_lr):
     """
-    Tests the 2d plotting functionality of plot_results_panel.
+    Test slicing of 2d plotter using built-in slice() function.
     """
     steps = 51
 
@@ -390,20 +390,15 @@ def test_2d_plot_slicing(cycle_lr):
     assert len(fig2.axes) == 6
     assert sum([s.axison for s in fig2.axes]) == 4
 
-    # Only final plot
-    fig3 = plot_results_panel_2d(
-        cycle_lr,
-        steps=steps,
-        query=slice(-1, None, None),
-        subplot_kw={"sharex": True, "sharey": True},
-    )
-    # Should have 1 axes
-    assert len(fig3.axes) == 1
-    assert sum([s.axison for s in fig3.axes]) == 1
 
-    # Using np.s_ Index Expression
+def test_2d_plot_slicing_np(cycle_lr):
+    """
+    Test slicing of 2d plotter using np.s_ Index Expression
+    """
+    steps = 51
+
     # Cycles 0, 2, 4, 6, 8
-    fig4 = plot_results_panel_2d(
+    fig1 = plot_results_panel_2d(
         cycle_lr,
         steps=steps,
         wrap=3,
@@ -411,10 +406,10 @@ def test_2d_plot_slicing(cycle_lr):
         subplot_kw={"sharex": True, "sharey": True},
     )
     # Should have 6 axes, 5 with data and the last turned off
-    assert len(fig4.axes) == 6
-    assert sum([s.axison for s in fig4.axes]) == 5
+    assert len(fig1.axes) == 6
+    assert sum([s.axison for s in fig1.axes]) == 5
 
-    fig5 = plot_results_panel_2d(
+    fig2 = plot_results_panel_2d(
         cycle_lr,
         steps=steps,
         wrap=3,
@@ -422,5 +417,42 @@ def test_2d_plot_slicing(cycle_lr):
         subplot_kw={"sharex": True, "sharey": True},
     )
     # Should have 6 axes, 4 with data
-    assert len(fig5.axes) == 6
-    assert sum([s.axison for s in fig5.axes]) == 4
+    assert len(fig2.axes) == 6
+    assert sum([s.axison for s in fig2.axes]) == 4
+
+
+def test_2d_plot_plot_single(cycle_lr):
+    """
+    Test query of 2d plotter for a single cycle.
+    """
+    steps = 51
+
+    # Using index
+    fig1 = plot_results_panel_2d(
+        cycle_lr,
+        steps=steps,
+        query=[9],
+        subplot_kw={"sharex": True, "sharey": True},
+    )
+    assert len(fig1.axes) == 1
+    assert sum([s.axison for s in fig1.axes]) == 1
+
+    # Using slice()
+    fig2 = plot_results_panel_2d(
+        cycle_lr,
+        steps=steps,
+        query=slice(-1, None, None),
+        subplot_kw={"sharex": True, "sharey": True},
+    )
+    assert len(fig2.axes) == 1
+    assert sum([s.axison for s in fig2.axes]) == 1
+
+    # Using np.s_ Index expression
+    fig3 = plot_results_panel_2d(
+        cycle_lr,
+        steps=steps,
+        query=np.s_[-1:],
+        subplot_kw={"sharex": True, "sharey": True},
+    )
+    assert len(fig3.axes) == 1
+    assert sum([s.axison for s in fig3.axes]) == 1

--- a/tests/test_cycle_plots.py
+++ b/tests/test_cycle_plots.py
@@ -140,6 +140,9 @@ def cycle_multi_lr(ground_truth_2x):
         experiment_runner=example_synthetic_experiment_runner,
     )
 
+    # Run 6 iterations
+    cycle.run(6)
+
     return cycle
 
 
@@ -214,7 +217,6 @@ def test_2d_plot(cycle_lr):
 
 
 def test_3d_plot(cycle_multi_lr):
-    cycle_multi_lr.run(6)
     steps = 20
     fig = plot_results_panel_3d(
         cycle_multi_lr,
@@ -309,7 +311,7 @@ def test_cycle_score_plot(cycle_lr, ground_truth_1x):
 
 
 def test_cycle_score_plot_multi_lr(cycle_multi_lr, ground_truth_2x):
-    cycle_multi_lr.run(12)
+    cycle_multi_lr.run(6)  # Run additional 6 times, total of 12 cycles
     X_test = np.array(
         list(grid_pool(cycle_multi_lr.data.metadata.independent_variables))
     )


### PR DESCRIPTION
## Description

Refactored the tests for the cycle plotters to be more efficient. 
* Previously each test was running the cycle passed from a pytest fixture. I moved the running of the cycle into the fixture so that it only needs to run one time. 
* I also split some of the larger tests into smaller tests so errors can be more easily identified and traced.

### Type of change:
- Optimization 
