### PR TITLE
chore: upgrade isort in pre-commit to avoid build failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args:


### PR DESCRIPTION
## Description

upgrade the version of isort in `pre-commit-config.yaml` to avoid build failure.

fixes #261 

### Type of change:
- Bug fix (non-breaking change which fixes an issue)

### Features: 
- bump isort from 5.10.1 to 5.12.0

### Questions: 
- is this actually the relevant issue?
- if so, is this where/how it should be fixed (ie, with a simple branch off main)?
- is there anything within dependabot itself that needs to updated?

### Remarks: 
- first looked at the details of the build failure: https://github.com/AutoResearch/autora/actions/runs/4055928636/jobs/6979735632
- then googled the RunTimeError message, which got me here: https://github.com/home-assistant/core/issues/86892#issuecomment-1407641288