### PR TITLE
Feat: upgrade SimpleCycle with more flexible planning of Executions

### DIFF
--- a/autora/cycle/_planner.py
+++ b/autora/cycle/_planner.py
@@ -93,6 +93,7 @@ def random_operation_planner(
         >>> state = {}
 
         We simulate a productive executor_collection using a SimpleNamespace
+        >>> from types import SimpleNamespace
         >>> executor_collection = SimpleNamespace(
         ...     experimentalist = "experimentalist",
         ...     experiment_runner = "experiment_runner",

--- a/autora/cycle/_planner.py
+++ b/autora/cycle/_planner.py
@@ -1,0 +1,122 @@
+import random
+from typing import Any, Protocol
+
+from autora.cycle._executor import (
+    Executor,
+    SupportsExperimentalistExperimentRunnerTheorist,
+    SupportsFullCycle,
+)
+from autora.cycle._state import ResultKind, SupportsConditionsObservationsTheories
+
+
+class Planner(Protocol):
+    def __call__(self, state, executor_collection) -> Executor:
+        ...
+
+
+def full_cycle_planner(state: Any, executor_collection: SupportsFullCycle):
+    """Always returns the `full_cycle` method."""
+    return executor_collection.full_cycle
+
+
+def last_result_kind_planner(
+    state: SupportsConditionsObservationsTheories,
+    executor_collection: SupportsExperimentalistExperimentRunnerTheorist,
+):
+    """
+    Chooses the operation based on the last result, e.g. new theory -> run experimentalist.
+
+    Interpretation: The "traditional" AutoRA Controller – a systematic research assistant.
+
+    Examples:
+        We initialize a new CycleState to run our planner on:
+        >>> from autora.cycle._state import CycleState
+        >>> state = CycleState()
+
+        We simulate a productive executor_collection using a SimpleNamespace
+        >>> from types import SimpleNamespace
+        >>> executor_collection = SimpleNamespace(
+        ...     experimentalist = "experimentalist",
+        ...     experiment_runner = "experiment_runner",
+        ...     theorist = "theorist",
+        ... )
+
+        Based on the results available in the state, we can get the next kind of executor we need.
+        When we have no results of any kind, we get an experimentalist:
+        >>> last_result_kind_planner(state, executor_collection)
+        'experimentalist'
+
+        ... or if we had produced conditions, then we could run an experiment
+        >>> state.update("some theory", kind="CONDITION")
+        >>> last_result_kind_planner(state, executor_collection)
+        'experiment_runner'
+
+        ... or if we last produced observations, then we could now run the theorist:
+        >>> state.update("some theory", kind="OBSERVATION")
+        >>> last_result_kind_planner(state, executor_collection)
+        'theorist'
+
+        ... or if we last produced a theory, then we could now run the experimentalist:
+        >>> state.update("some theory", kind="THEORY")
+        >>> last_result_kind_planner(state, executor_collection)
+        'experimentalist'
+
+    """
+
+    try:
+        last_result_kind = state.conditions_observations_theories[-1].kind
+    except IndexError:
+        last_result_kind = None
+
+    callback = {
+        None: executor_collection.experimentalist,
+        ResultKind.THEORY: executor_collection.experimentalist,
+        ResultKind.CONDITION: executor_collection.experiment_runner,
+        ResultKind.OBSERVATION: executor_collection.theorist,
+    }[last_result_kind]
+
+    return callback
+
+
+def random_operation_planner(
+    _, executor_collection: SupportsExperimentalistExperimentRunnerTheorist
+):
+    """
+    Chooses a random operation, ignoring any data which already exist.
+
+    Interpretation: A mercurial PI with good technique but poor planning, who doesn't remember what
+    they did last.
+
+    Examples:
+        This planner completely ignores the state, so we can simulate it by using anything we
+        like, here we choose the empty set:
+        >>> state = {}
+
+        We simulate a productive executor_collection using a SimpleNamespace
+        >>> executor_collection = SimpleNamespace(
+        ...     experimentalist = "experimentalist",
+        ...     experiment_runner = "experiment_runner",
+        ...     theorist = "theorist",
+        ... )
+
+        For reproducibility, we seed the random number generator consistently:
+        >>> from random import seed
+        >>> seed(42)
+
+        Now we can begin to see which operations are returned by the planner. The first (for this
+        seed) is the theorist.
+        >>> random_operation_planner(state, executor_collection)
+        'theorist'
+
+        If we evaluate again, a random executor will be suggested each time
+        >>> [random_operation_planner(state, executor_collection) for i in range(5)]
+        ['experimentalist', 'experimentalist', 'theorist', 'experiment_runner', 'experimentalist']
+
+    """
+    options = [
+        executor_collection.experimentalist,
+        executor_collection.experiment_runner,
+        executor_collection.theorist,
+    ]
+    choice = random.choice(options)
+    return choice

--- a/autora/cycle/_state.py
+++ b/autora/cycle/_state.py
@@ -1,28 +1,146 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from enum import Enum
+from typing import Any, Dict, List, Optional, Protocol, Sequence
 
-import numpy as np
+from numpy._typing import ArrayLike
 from sklearn.base import BaseEstimator
 
 from autora.variable import VariableCollection
 
 
-@dataclass(frozen=True)
+class ResultKind(Enum):
+    CONDITION = "CONDITION"
+    OBSERVATION = "OBSERVATION"
+    THEORY = "THEORY"
+    PARAMS = "PARAMS"
+    METADATA = "METADATA"
+
+    def __repr__(self):
+        cls_name = self.__class__.__name__
+        return f"{cls_name}.{self.name}"
+
+
+@dataclass
+class Result:
+    data: Any
+    kind: ResultKind
+
+
+@dataclass
 class CycleState:
-    """An object passed between and updated by processing steps in the SimpleCycle."""
+    result_sequence: List[Result] = field(default_factory=list)
 
-    # Static
-    metadata: VariableCollection = field(default_factory=VariableCollection)
+    def __init__(
+        self,
+        result_sequence: Optional[Sequence[Result]] = None,
+        conditions: Optional[Sequence[ArrayLike]] = None,
+        observations: Optional[Sequence[ArrayLike]] = None,
+        theories: Optional[Sequence[BaseEstimator]] = None,
+        metadata: Optional[VariableCollection] = None,
+        params: Optional[Dict] = None,
+    ):
+        if result_sequence is not None:
+            self.result_sequence = list(result_sequence)
+        else:
+            self.result_sequence = []
 
-    # Potentially variable parameters
-    params: Dict = field(default_factory=dict)
+        for seq, kind in [
+            (conditions, ResultKind.CONDITION),
+            (observations, ResultKind.OBSERVATION),
+            (theories, ResultKind.THEORY),
+        ]:
+            if seq is not None:
+                for i in seq:
+                    self.update(i, kind=kind)
 
-    # Aggregates each cycle from the:
-    # ... Experimentalist
-    conditions: List[np.ndarray] = field(default_factory=list)
-    # ... Experiment Runner
-    observations: List[np.ndarray] = field(default_factory=list)
-    # ... Theorist
-    theories: List[BaseEstimator] = field(default_factory=list)
+        if metadata is not None:
+            self.metadata = metadata
+
+        if params is not None:
+            self.params = params
+
+    def update(self, data, kind):
+        self.result_sequence.append(Result(data, ResultKind(kind)))
+
+    @property
+    def metadata(self) -> VariableCollection:
+        try:
+            m = self._get_last_data_by_kind(kind={ResultKind.METADATA})
+        except StopIteration:
+            m = VariableCollection()
+        return m
+
+    @metadata.setter
+    def metadata(self, value):
+        self.update(value, kind=ResultKind.METADATA)
+
+    @property
+    def params(self) -> Dict:
+        try:
+            p = self._get_last_data_by_kind(kind={ResultKind.PARAMS})
+        except StopIteration:
+            p = dict()
+        return p
+
+    @params.setter
+    def params(self, value):
+        self.update(value, kind=ResultKind.PARAMS)
+
+    @property
+    def conditions(self) -> List[ArrayLike]:
+        return list(
+            self._filter_data_by_kind(self.result_sequence, kind={ResultKind.CONDITION})
+        )
+
+    @property
+    def observations(self) -> List[ArrayLike]:
+        return list(
+            self._filter_data_by_kind(
+                self.result_sequence, kind={ResultKind.OBSERVATION}
+            )
+        )
+
+    @property
+    def theories(self) -> List[BaseEstimator]:
+        return list(
+            self._filter_data_by_kind(self.result_sequence, kind={ResultKind.THEORY})
+        )
+
+    @property
+    def conditions_observations_theories(self) -> List[Result]:
+        return list(
+            self._filter_result_by_kind(
+                self.result_sequence,
+                kind={ResultKind.CONDITION, ResultKind.OBSERVATION, ResultKind.THEORY},
+            )
+        )
+
+    def _get_last_data_by_kind(self, kind):
+        results_new_to_old = reversed(self.result_sequence)
+        last_of_kind = next(self._filter_data_by_kind(results_new_to_old, kind=kind))
+        return last_of_kind
+
+    @staticmethod
+    def _filter_data_by_kind(result_sequence: Sequence[Result], kind: set[ResultKind]):
+        return (
+            r.data
+            for r in CycleState._filter_result_by_kind(result_sequence, kind=kind)
+        )
+
+    @staticmethod
+    def _filter_result_by_kind(
+        result_sequence: Sequence[Result], kind: set[ResultKind]
+    ):
+        for r in result_sequence:
+            if r.kind in kind:
+                yield r
+
+
+class SupportsResultSequence(Protocol):
+    result_sequence: Sequence[Result]
+
+
+class SupportsConditionsObservationsTheories(Protocol):
+    conditions_observations_theories: Sequence[Result]


### PR DESCRIPTION
## Description

Extends #291 with a switchable "planner" component – instead of having to run the whole cycle each time you call `next(cycle)`, a single step (`theorist` OR `experimentalist` OR `experiment_runner`) can be run.

These changes also make serializing and deserializing the cycle's state simpler, and allow for tracking changes to parameters and even metadata over time.

Required (but not sufficient) for #238 .

### Type of change:
*Delete as appropriate:*
- New feature (non-breaking change which adds functionality)

### Features: 
- Remodel the CycleState class – it is now built around a single list which contains the config (metadata and fit parameters) and the results (conditions, observations and theories) in the sequence in which they were available. 
- Add a planner function which looks at the last result and chooses the next operation based on that result. This allows for simple seeding of the cycle.
- Add a planner function which chooses the next operation at random (demonstrating arbitrary evaluation order)
- Update the SimpleCycle to use the planner function (and update its documentation)