### PR TITLE
fix: Turn off Poetry modern installer 

### DIFF
--- a/.github/workflows/test-pytest.yml
+++ b/.github/workflows/test-pytest.yml
@@ -24,5 +24,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: "poetry"
+    - run: poetry config installer.modern-installation false
     - run: poetry install
     - run: poetry run pytest


### PR DESCRIPTION
This correct and issue with and invalid `debugpy` wheel with Poetry v1.4.1 modern installer. This was causing an issue during GitHub action pytests. 

## Description

Provide a high-level summary of the change and which issue (either on Github or Notion) is fixed. Please also include relevant motivation and context.

_Fixes #(issue)_ (if the issue is on Github, simply link to it using the '#' symbol; otherwise, provide a notion page link)

### Type of change:
- Bug fix (non-breaking change which fixes an issue)

### Features: 
- Updated GitHub action test-pytest.yml to turn Poetry's modern installer off.

### Questions: 
- Do we need to do this for any other actions? 
