### PR TITLE
refactor: replace legacy 'numpy.random' function with objects from Random Generator class

### DIFF
--- a/autora/synthetic/data/weber_fechner.py
+++ b/autora/synthetic/data/weber_fechner.py
@@ -81,7 +81,7 @@ def weber_fechner_law(
         for idx, x in enumerate(X):
             # jnd =  np.min(x) * weber_constant
             # response = (x[1]-x[0]) - jnd
-            # y = 1/(1+np.exp(-response)) + np.random.normal(0, std)
+            # y = 1/(1+np.exp(-response)) + rng.normal(0, std)
             y = constant * np.log(x[1] / x[0]) + rng.normal(0, std)
             Y[idx] = y
 

--- a/autora/theorist/bms/mcmc.py
+++ b/autora/theorist/bms/mcmc.py
@@ -1491,12 +1491,12 @@ class Tree:
 # -----------------------------------------------------------------------------
 
 
-def test3(num_points=10, samples=100000):
+def test3(num_points=10, samples=100000, rng=np.random.default_rng()):
     # Create the data
     x = pd.DataFrame(
-        dict([("x%d" % i, np.random.uniform(0, 10, num_points)) for i in range(5)])
+        dict([("x%d" % i, rng.uniform(0, 10, num_points)) for i in range(5)])
     )
-    eps = np.random.normal(0.0, 5, num_points)
+    eps = rng.normal(0.0, 5, num_points)
     y = 50.0 * np.sin(x["x0"]) / x["x2"] - 4.0 * x["x1"] + 3 + eps
     x.to_csv("data_x.csv", index=False)
     y.to_csv("data_y.csv", index=False, header=["y"])
@@ -1525,12 +1525,12 @@ def test3(num_points=10, samples=100000):
     return t
 
 
-def test4(num_points=10, samples=1000):
+def test4(num_points=10, samples=1000, rng=np.random.default_rng()):
     # Create the data
     x = pd.DataFrame(
-        dict([("x%d" % i, np.random.uniform(0, 10, num_points)) for i in range(5)])
+        dict([("x%d" % i, rng.uniform(0, 10, num_points)) for i in range(5)])
     )
-    eps = np.random.normal(0.0, 5, num_points)
+    eps = rng.normal(0.0, 5, num_points)
     y = 50.0 * np.sin(x["x0"]) / x["x2"] - 4.0 * x["x1"] + 3 + eps
     x.to_csv("data_x.csv", index=False)
     y.to_csv("data_y.csv", index=False, header=["y"])

--- a/autora/theorist/darts/model_search.py
+++ b/autora/theorist/darts/model_search.py
@@ -416,7 +416,10 @@ class Network(nn.Module):
         return
 
     def sample_alphas_normal(
-        self, sample_amp: float = 1, fair_darts_weight_threshold: float = 0
+        self,
+        sample_amp: float = 1,
+        fair_darts_weight_threshold: float = 0,
+        rng=np.random.default_rng(),
     ) -> torch.Tensor:
         """
         Samples an architecture from the mixed operations from a probability distribution that is
@@ -428,6 +431,7 @@ class Network(nn.Module):
             sample_amp: temperature that is applied before passing the weights through a softmax
             fair_darts_weight_threshold: used in fair DARTS. If an architecture weight is below
                 this value then it is set to zero.
+            rng: initialization of random generator object
 
         Returns:
             alphas_normal_sample: sampled architecture weights.
@@ -466,7 +470,7 @@ class Network(nn.Module):
                 )
                 k_sample = random.randrange(len(W_soft))
             else:
-                k_sample = np.random.choice(range(len(W_soft)), p=W_soft.data.numpy())
+                k_sample = rng.choice(range(len(W_soft)), p=W_soft.data.numpy())
             alphas_normal_sample[edge, k_sample] = 1
 
         return alphas_normal_sample
@@ -490,7 +494,7 @@ class Network(nn.Module):
         return alphas_normal_sample
 
     # returns the genotype of the model
-    def genotype(self, sample: bool = False) -> Genotype:
+    def genotype(self, sample: bool = False, rng=np.random.default_rng()) -> Genotype:
         """
         Computes a genotype of the model which specifies the current computation graph based on
         the largest architecture weight for each edge, or based on a sample.
@@ -501,6 +505,7 @@ class Network(nn.Module):
                 from a probability distribution that is determined by the
                 softmaxed architecture weights. If set to false (default), the architecture will be
                 determined based on the largest architecture weight per edge.
+            rng: initialization of random generator object
 
         Returns:
             genotype: genotype describing the current (sampled) architecture
@@ -538,9 +543,7 @@ class Network(nn.Module):
                 ) in edges:  # looping through all the edges for the current node (i)
                     if sample:
                         W_soft = F.softmax(Variable(torch.from_numpy(W[j])))
-                        k_best = np.random.choice(
-                            range(len(W[j])), p=W_soft.data.numpy()
-                        )
+                        k_best = rng.choice(range(len(W[j])), p=W_soft.data.numpy())
                     else:
                         k_best = None
                         # looping through all the primitives

--- a/tests/test_bms_mcmc.py
+++ b/tests/test_bms_mcmc.py
@@ -6,7 +6,10 @@ from autora.theorist.bms import Tree, get_priors
 
 
 def test_tree_mcmc_stepping(
-    num_points: int = 10, samples: int = 100, show_plot: bool = False
+    num_points: int = 10,
+    samples: int = 100,
+    show_plot: bool = False,
+    rng=np.random.default_rng(),
 ) -> Tree:
     """
     Testing the basic MCMC capacity. Note that even though an option (`show_plot`) is
@@ -22,6 +25,8 @@ def test_tree_mcmc_stepping(
             calculated as `burnin` + `samples`
         show_plot:
             whether to plot the predicted against actual response variable
+        rng:
+            initialization of random generator object
 
     Returns:
         the expression tree obtained from running the MCMC algorithm
@@ -29,9 +34,9 @@ def test_tree_mcmc_stepping(
 
     # Create the data
     x = pd.DataFrame(
-        dict([("x%d" % i, np.random.uniform(0, 10, num_points)) for i in range(5)])
+        dict([("x%d" % i, rng.uniform(0, 10, num_points)) for i in range(5)])
     )
-    eps = np.random.normal(0.0, 5, num_points)
+    eps = rng.normal(0.0, 5, num_points)
     y = 50.0 * np.sin(x["x0"]) / x["x2"] - 4.0 * x["x1"] + 3 + eps
 
     # Create the formula

--- a/tests/test_experimentalist_assumption.py
+++ b/tests/test_experimentalist_assumption.py
@@ -21,7 +21,7 @@ def test_experimentalist_assumption():
     def ground_truth(xs):
         return (xs**2.0) + xs + 1.0
 
-    # X = np.random.randint(low=0, high=10, size=100).reshape(-1, 1)
+    # X = np.random.default_rng().integers(low=0, high=10, size=100).reshape(-1, 1)
     X = np.array(range(11)).reshape(-1, 1)
     y = np.array([x for x in ground_truth(X)])
 


### PR DESCRIPTION
# Description

In various places, our theorists were relying upon the legacy `numpy.random{...}` function. This PR replaces instances of that legacy function with objects from the new Random Generator class.

- resolves #326 

# Type of change

- **refactor**: A code change that neither fixes a bug nor adds a feature

# Features (Optional)
- all legacy `numpy.random{...}` functions replaced with random generator objects

# Questions (Optional)
- Should the generator object — `rng=np.random.default_rng()` — always be passed as an argument, as opposed to initialized and used merely within the body of code?

# Remarks (Optional)
- I tried to grab all instances, which were spread across DARTS, BMS, and BSR to varying degrees.
