### PR TITLE
Docs add tutorials

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,7 +76,7 @@ extra_javascript: [
 nav:
 - Introduction: 'index.md'
 - Tutorials:
-  - Introduction: 'tutorials/index.md'
+  - Home: 'tutorials/index.md'
   - Automated Theorist: 'bms-tutorial/docs/Basic Usage.ipynb'
   - Automated Experimentalist: 'falsification-tutorial/docs/sampler/Basic Usage.ipynb'
   - Closed-Loop Discovery: 'workflow-tutorial/docs/interactive/Basic Usage.ipynb'


### PR DESCRIPTION
# Description

add the tutorials after the introduction

# Remarks (Optional)
This works, but since mkdocs doesn't seem to support having the same file (or import) at two different nav endpoints, a workaround is to import the falsification sampler twice


