### PR TITLE
ci: add trigger to publish every night

### DIFF
--- a/.github/workflows/publish-documentation-gh-pages.yml
+++ b/.github/workflows/publish-documentation-gh-pages.yml
@@ -1,6 +1,8 @@
 name: Publish Documentation to GitHub Pages
 
 on:
+  schedule:
+    - cron: '59 3 * * *' # this triggers deployment every night at 3:59 UTC / 23:59 EST
   workflow_dispatch:  # this allows us to run it manually
   release:
     types: [released]  # only deploy when we make a new `latest` release


### PR DESCRIPTION
# Description

Adds trigger to publish documentation every night at 3:59 UTC / 23:59 EST

Fixes #437 

# Type of change

- **ci**: Changes to our CI configuration files and scripts (i.e., those in the .github directory)

# Features (Optional)
- additional event to trigger `publish-documentation-gh-pages.yml`
