### PR TITLE
docs: update button to open in colab

### DIFF
--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -8,7 +8,7 @@
     </a>
     <a href="{{ config.extra.colab_base_url }}{{ page.url }}{{ page.file.src_uri | basename | quote }}"
        title="Open Notebook in Google Colab" class="md-content__button md-icon">
-        {% include ".icons/material/play-circle-outline.svg" %}
+        <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
     </a>
 {% endif %}
 {{ super() }}


### PR DESCRIPTION
# Description

Update button for opening in colab – use the standard button used everywhere.

# Type of change

- **docs**: Documentation only changes

<img width="686" alt="Screenshot 2023-06-21 at 10 58 03" src="https://github.com/AutoResearch/autora/assets/2803227/694c5029-f9af-4ad5-8318-9291a0abc727">
