### PR TITLE
ci: add push-to-main-branch as event to trigger publishing documentation

### DIFF
--- a/.github/workflows/publish-documentation-gh-pages.yml
+++ b/.github/workflows/publish-documentation-gh-pages.yml
@@ -1,8 +1,9 @@
 name: Publish Documentation to GitHub Pages
 
 on:
-  merge_group:
-    types: [checks_requested]  # when a pull request is added to a merge queue
+  push:
+    branches:
+      - 'main' # when someone pushes to the 'main' branch
   schedule:
     - cron: '59 3 * * *' # this triggers deployment every night at 3:59 UTC / 23:59 EST
   workflow_dispatch:  # this allows us to run it manually

--- a/.github/workflows/publish-documentation-gh-pages.yml
+++ b/.github/workflows/publish-documentation-gh-pages.yml
@@ -1,6 +1,8 @@
 name: Publish Documentation to GitHub Pages
 
 on:
+  merge_group:
+    types: [checks_requested]  # when a pull request is added to a merge queue
   schedule:
     - cron: '59 3 * * *' # this triggers deployment every night at 3:59 UTC / 23:59 EST
   workflow_dispatch:  # this allows us to run it manually


### PR DESCRIPTION
# Description

resolves #490 

# Type 

- **ci**: Changes to our CI configuration files and scripts (i.e., those in the .github directory)

# Questions (Optional)
- i'm not entirely sure this is what you [meant](https://autonomousemp-x117217.slack.com/archives/C053US2PP4H/p1687531732057319), @younesStrittmatter. info on `merge_group` trigger can be found here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
