### PR TITLE
docs: include tutorial for online experiment

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,11 @@ plugins:
           "docs/pooler/*",
           "src/"
         ]
+      - name: user-cookiecutter
+        import_url: "https://github.com/autoresearch/autora-user-cookiecutter/?branch=main"
+        imports: [
+          "docs/*",
+        ]
       - name: workflow-tutorial
         import_url: "https://github.com/autoresearch/autora-workflow/?branch=main"
         imports: ["docs/*"]
@@ -151,6 +156,7 @@ nav:
   - Automated Theorist: 'tutorials/Theorist.ipynb'
   - Automated Experimentalist: 'tutorials/Experimentalist.ipynb'
   - Closed-Loop Discovery: 'workflow-tutorial/docs/interactive/Basic Usage.ipynb'
+  - Online Closed-Loop Discovery: 'user-cookiecutter/docs/index.md'
 - User Guide:
   - Theorists:
     - Home: 'theorist/index.md'


### PR DESCRIPTION
# Description

- resolves #395

add the documentation from the [user cookiecutter](https://github.com/AutoResearch/autora-user-cookiecutter/blob/main/docs/index.md)


# Type of change

*Delete as appropriate:*
- **docs**: Documentation only changes


# Questions (Optional)
Not exactly a jupiter notebook tutorial. Describes the process of setting up and AutoRA workflow + Firebase Website in a way so they can be used together. 

# Remarks (Optional)
The cookiecutter basic example will be updated accordingly additionally (this works as an example and gets a closed loop running, but is not updated with some recent changes in the packages)

