### PR TITLE
docs: update page names in tutorials

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,8 +153,8 @@ nav:
 - Introduction: 'index.md'
 - Tutorials:
   - Home: 'tutorials/index.md'
-  - Automated Theorist: 'tutorials/Theorist.ipynb'
-  - Automated Experimentalist: 'tutorials/Experimentalist.ipynb'
+  - Theorists: 'tutorials/Theorist.ipynb'
+  - Experimentalists: 'tutorials/Experimentalist.ipynb'
   - Closed-Loop Discovery: 'workflow-tutorial/docs/interactive/Basic Usage.ipynb'
   - Online Closed-Loop Discovery: 'user-cookiecutter/docs/index.md'
 - User Guide:


### PR DESCRIPTION
# Description

i believe this was the only place we refer to "Automated Theorist" and "Automated Experimentalist", so simplifying to conform. eg, under User Guide, it's just "Theorists" and "Experimentalists"

# Type of change

- **docs**: Documentation only changes
