### PR TITLE
503 fix broken links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,8 @@ AutoRA consists of different modules that can be used independently or in combin
 AutoRA can be used for a variety of research purposes in empirical sciences, such as psychology, 
 neuroscience, economics, physics, or materials science. Usages, as illustrated in the following tutorials, include:
 
-- [**Equation discovery**](tutorials/theorist.ipynb) from empirical data
-- [**Experimental design**](tutorials/experimentalist.ipynb) for follow-up experiments
+- [**Equation discovery**](tutorials/Theorist.ipynb) from empirical data
+- [**Experimental design**](tutorials/Experimentalist.ipynb) for follow-up experiments
 - **Research documentation and dissemination**
 - **Closed-loop empirical research**
 - **Computational analyses of the scientific process** (metascience, computational philosophy of science)

--- a/docs/online-experiments/firebase.md
+++ b/docs/online-experiments/firebase.md
@@ -1,6 +1,6 @@
 # Firebase Integration
 
-On this page, you can find information on how to set up a [Firebase](https://firebase.google.com/) website to collect observations for an AutoRA workflow. You can find information on how to connect such a website to AutoRA and how to automatically recruit participants via [Prolific](https://www.prolific.co/) at the following pages, respectively: [AutoRA Firebase Experimentation manager](user-guide/experiment-runners/experimentation-managers/firebase/), [AutoRA Prolific Recruitment Manager](user-guide/experiment-runners/recruitment-managers/prolific/).
+On this page, you can find information on how to set up a [Firebase](https://firebase.google.com/) website to collect observations for an AutoRA workflow. You can find information on how to connect such a website to AutoRA and how to automatically recruit participants via [Prolific](https://www.prolific.co/) at the following pages, respectively: [AutoRA Firebase Experimentation manager](../../user-guide/experiment-runners/experimentation-managers/firebase), [AutoRA Prolific Recruitment Manager](../../user-guide/experiment-runners/recruitment-managers/prolific/).
 
 For setting up the online experiment, we recommend using either the [user cookiecutter template](https://github.com/AutoResearch/autora-user-cookiecutter) or the [create-react-app template](https://github.com/AutoResearch/cra-template-autora-firebase).
 
@@ -91,10 +91,10 @@ You can test the experiment locally using
 ```shell
 npm start
 ```
-During development, the Firestore database will not be used. If you want to load conditions from the database, you need to upload them first (for example using the [AutoRA Firebase Experimentation Manager](user-guide/experiment-runners/experimentation-managers/firebase/)) and set `REACT_APP_devNoDb="False"` in the `.env` file.
+During development, the Firestore database will not be used. If you want to load conditions from the database, you need to upload them first (for example using the [AutoRA Firebase Experimentation Manager](../../user-guide/experiment-runners/experimentation-managers/firebase/)) and set `REACT_APP_devNoDb="False"` in the `.env` file.
 
 ### Using Prolific Id's
-If you want to recruit participants via Prolific (for example using the [AutoRA Prolific Recruitment Manager](user-guide/experiment-runners/recruitment-managers/prolific/)), we ***highly recommend*** setting `REACT_APP_useProlificId="True"`. This will speed up the recruitment of participants.
+If you want to recruit participants via Prolific (for example using the [AutoRA Prolific Recruitment Manager](../../user-guide/experiment-runners/recruitment-managers/prolific/)), we ***highly recommend*** setting `REACT_APP_useProlificId="True"`. This will speed up the recruitment of participants.
 
 ## Build And Deploy To Firebase 
 To serve the website on the internet, you must build and deploy it to Firebase.

--- a/docs/tutorials/Experimentalist.ipynb
+++ b/docs/tutorials/Experimentalist.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "# Experimentalist Tutorial\n",
     "\n",
-    "[Experimentalists](../../experimentalist/) are functions designed to return novel experimental conditions that yield scientific merit.\n",
+    "[Experimentalists](../experimentalist/index.md) are functions designed to return novel experimental conditions that yield scientific merit.\n",
     "\n",
     "![Experimentalist](attachment:experimentalist.png)\n",
     "\n",

--- a/docs/tutorials/Experimentalist.ipynb
+++ b/docs/tutorials/Experimentalist.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "# Experimentalist Tutorial\n",
     "\n",
-    "[Experimentalists](../experimentalist/index.md) are functions designed to return novel experimental conditions that yield scientific merit.\n",
+    "[Experimentalists](../../experimentalist/) are functions designed to return novel experimental conditions that yield scientific merit.\n",
     "\n",
     "![Experimentalist](attachment:experimentalist.png)\n",
     "\n",

--- a/docs/tutorials/Theorist.ipynb
+++ b/docs/tutorials/Theorist.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "# Theorist Tutorial\n",
     "\n",
-    "[Theorists](../theorist/index.md) are classes designed to automate the construction of interpretable models from data. AutoRA theorists are implemented as sklearn regressors and can be used with the `fit` and `predict` methods.\n",
+    "[Theorists](../../theorist) are classes designed to automate the construction of interpretable models from data. AutoRA theorists are implemented as sklearn regressors and can be used with the `fit` and `predict` methods.\n",
     "\n",
     "![Theorist](attachment:theorist.png)\n",
     "\n",


### PR DESCRIPTION
# Description

- resolves #503

# Type of change

*Delete as appropriate:*
- **docs**: Documentation only changes


# Questions (Optional)
the links in the jupiter notebooks work, but it doesn't seem right. I brievly looked into the mkdocs-jupiter plugin documentation but didn't find much. I'll work on it when I find time, but this is a quick fix so at least it works. 