### PR TITLE
docs: add details on publishing via Github Actions

### DIFF
--- a/docs/contribute/modules/index.md
+++ b/docs/contribute/modules/index.md
@@ -74,7 +74,7 @@ There are several ways to publish your package, depending on how you set up your
 ### Publishing Via GitHub Actions
 If you used the **cookiecutter template** with the advanced setup, and uploaded your repository to github.com, then you can use Github Actions to automatically publish your package to PyPI or Conda. 
 
-Note that if your repository is part of the [AutoRA Organisation](https://github.com/AutoResearch) you can skip the creation of a secret in your repository.
+Note, if your repository is part of the [AutoResearch Organization](https://github.com/AutoResearch) you can skip the step below for creating a new secret in your repository.
 
 1. Add an API Token to the GitHub Secrets
     - Create a [PyPi account](https://pypi.org/) if you don't have one already.

--- a/docs/contribute/modules/index.md
+++ b/docs/contribute/modules/index.md
@@ -77,7 +77,7 @@ If you used the **cookiecutter template** with the advanced setup, and uploaded 
 Note, if your repository is part of the [AutoResearch Organization](https://github.com/AutoResearch) you can skip the step below for creating a new secret in your repository.
 
 1. Add an API Token to the GitHub Secrets
-    - Create a [PyPi account](https://pypi.org/) if you don't have one already.
+    - Create a [PyPI account](https://pypi.org/) if you don't have one already.
     - Once you have an account, generate an API token for your account.
     - In your GitHub repository, go `Settings`.
     - Under `Secrets and Variables`, create a new secret named `PYPI_API_TOKEN` and paste your PyPI API token as the value.

--- a/docs/contribute/modules/index.md
+++ b/docs/contribute/modules/index.md
@@ -76,7 +76,7 @@ If you used the **cookiecutter template** with the advanced setup, and uploaded 
 
 Note, if your repository is part of the [AutoResearch Organization](https://github.com/AutoResearch) you can skip the step below for creating a new secret in your repository.
 
-1. Add an API Token to the GitHub Secrets
+1. Add an API token to the GitHub Secrets
     - Create a [PyPI account](https://pypi.org/) if you don't have one already.
     - Once you have an account, generate an API token for your account.
     - In your GitHub repository, go `Settings`.

--- a/docs/contribute/modules/index.md
+++ b/docs/contribute/modules/index.md
@@ -88,7 +88,7 @@ Note, if your repository is part of the [AutoResearch Organization](https://gith
     - Once you create a new release, the GitHub Action will automatically trigger, and your package will be built and published to PyPI using the provided API token.
 
 ### Manually Publishing
-If you used the **unguided template**, or you want to manually publish your package, you can follow [step 7 in this guide](https://github.com/AutoResearch/autora-template).
+If you used the **unguided template**, or you want to manually publish your package, you can follow [step 7 in this guide](https://github.com/AutoResearch/autora-template#step-7-publish-your-package).
 
 Once you've published your module, you should take some time to celebrate and announce your contribution in the 
 [AutoRA forum](https://github.com/orgs/AutoResearch/discussions/categories/module-announcements).

--- a/docs/contribute/modules/index.md
+++ b/docs/contribute/modules/index.md
@@ -80,7 +80,8 @@ Note, if your repository is part of the [AutoResearch Organization](https://gith
     - Create a [PyPI account](https://pypi.org/) if you don't have one already.
     - Once you have an account, generate an API token for your account.
     - In your GitHub repository, go to `Settings`.
-    - Under `Secrets and Variables`, create a new secret named `PYPI_API_TOKEN` and paste your PyPI API token as the value.
+    - Under `Secrets and variables` in the left-hand menu, select `Actions`. 
+    - Create a new secret named `PYPI_API_TOKEN` and paste in your PyPI API token as the value.
 
 2. Create A New Release
     - Follow the steps outlined in the [GitHub documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for creating a new release. 

--- a/docs/contribute/modules/index.md
+++ b/docs/contribute/modules/index.md
@@ -71,10 +71,23 @@ pip install -e ".[dev]"
 
 There are several ways to publish your package, depending on how you set up your repository.
 
-- If you used the **cookiecutter template** with the advanced setup, and uploaded your repository to 
-github.com, then you can use Github Actions to automatically publish your package to PyPI or Conda. 
+### Publishing Via GitHub Actions
+If you used the **cookiecutter template** with the advanced setup, and uploaded your repository to github.com, then you can use Github Actions to automatically publish your package to PyPI or Conda. 
 
-- If you used the **unguided template**, or you want to manually publish your package, you can follow [step 7 in this guide](https://github.com/AutoResearch/autora-template).
+Note that if your repository is part of the [AutoRA Organisation](https://github.com/AutoResearch) you can skip the creation of a secret in your repository.
+
+1. Add an API Token to the GitHub Secrets
+    - Create a [PyPi account](https://pypi.org/) if you don't have one already.
+    - Once you have an account, generate an API token for your account.
+    - In your GitHub repository, go `Settings`.
+    - Under `Secrets and Variables`, create a new secret named `PYPI_API_TOKEN` and paste your PyPI API token as the value.
+
+2. Create A New Release
+    - Follow the steps outlined in the [GitHub documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for creating a new release. 
+    - Once you create a new release, the GitHub Action will automatically trigger, and your package will be built and published to PyPI using the provided API token.
+
+### Manually Publishing
+If you used the **unguided template**, or you want to manually publish your package, you can follow [step 7 in this guide](https://github.com/AutoResearch/autora-template).
 
 Once you've published your module, you should take some time to celebrate and announce your contribution in the 
 [AutoRA forum](https://github.com/orgs/AutoResearch/discussions/categories/module-announcements).

--- a/docs/contribute/modules/index.md
+++ b/docs/contribute/modules/index.md
@@ -79,7 +79,7 @@ Note, if your repository is part of the [AutoResearch Organization](https://gith
 1. Add an API token to the GitHub Secrets
     - Create a [PyPI account](https://pypi.org/) if you don't have one already.
     - Once you have an account, generate an API token for your account.
-    - In your GitHub repository, go `Settings`.
+    - In your GitHub repository, go to `Settings`.
     - Under `Secrets and Variables`, create a new secret named `PYPI_API_TOKEN` and paste your PyPI API token as the value.
 
 2. Create A New Release

--- a/docs/contribute/modules/index.md
+++ b/docs/contribute/modules/index.md
@@ -83,7 +83,7 @@ Note, if your repository is part of the [AutoResearch Organization](https://gith
     - Under `Secrets and variables` in the left-hand menu, select `Actions`. 
     - Create a new secret named `PYPI_API_TOKEN` and paste in your PyPI API token as the value.
 
-2. Create A New Release
+2. Create a new release
     - Follow the steps outlined in the [GitHub documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for creating a new release. 
     - Once you create a new release, the GitHub Action will automatically trigger, and your package will be built and published to PyPI using the provided API token.
 


### PR DESCRIPTION
add documentation for automatic publishing

solves #519

# Type of change
- **docs**: Documentation only changes

