### PR TITLE
ci: standardize repository issue labels with label syncer

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,34 @@
+# Labels for AutoResearch repos
+- name: bug
+  description: Something isn't working.
+  color: d73a4a
+- name: documentation
+  description: Improvements or additions to documentation.
+  color: 0075ca
+- name: duplicate
+  description: This issue or pull request already exists.
+  color: cfd3d7
+- name: enhancement
+  description: New feature or request.
+  color: a2eeef
+- name: good first issue
+  description: Good for newcomers.
+  color: 7057ff
+- name: invalid
+  description: This doesn't seem right.
+  color: e4e669
+- name: priority 0 - emergency
+  description: These can be blockers, or security issues, and should be resolved immediately.
+  color: f01b0c
+- name: priority 1 - needed
+  description: These are highly desirable to be fixed, ideally within 2 weeks.
+  color: f0580c
+- name: priority 2 - wanted
+  description: These should be addressed within 2 months.
+  color: f0910c
+- name: priority 3 - optional
+  description: Not time sensitive.
+  color: f0dd0c
+- name: wontfix
+  description: This will not be worked on.
+  color: ffffff

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,10 +1,6 @@
 name: Sync labels
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - .github/labels.yml
+  workflow_dispatch:  # this allows us to run it manually
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: micnncim/action-label-syncer@v1
         with:
-          manifest: path/to/manifest/labels.yml
+          manifest: .github/labels.yml
           repository: |
               AutoResearch/autora
               AutoResearch/autora-core

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,19 @@
+name: Sync labels
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        with:
+          manifest: path/to/manifest/labels.yml
+          repository: |
+              AutoResearch/autora
+              AutoResearch/autora-core
+          token: ${{ secrets.LABEL_SYNCER }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,4 +16,20 @@ jobs:
           repository: |
               AutoResearch/autora
               AutoResearch/autora-core
+              AutoResearch/autora-experimentalist-falsification
+              AutoResearch/autora-experimentalist-sampler-assumption
+              AutoResearch/autora-experimentalist-sampler-inequality
+              AutoResearch/autora-experimentalist-sampler-leverage
+              AutoResearch/autora-experimentalist-sampler-model-disagreement
+              AutoResearch/autora-experimentalist-sampler-nearest-value
+              AutoResearch/autora-experimentalist-sampler-novelty
+              AutoResearch/autora-experimentalist-sampler-uncertainty
+              AutoResearch/autora-experiment-runner-experimentation-manager-firebase
+              AutoResearch/autora-experiment-runner-firebase-prolific
+              AutoResearch/autora-experiment-runner-recruitment-manager-prolific
+              AutoResearch/autora-synthetic
+              AutoResearch/autora-theorist-bms
+              AutoResearch/autora-theorist-bsr
+              AutoResearch/autora-theorist-darts
+              AutoResearch/autora-workflow
           token: ${{ secrets.LABEL_SYNCER }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,6 +1,6 @@
 name: Sync labels
 on:
-  workflow_dispatch:  # this allows us to run it manually
+  workflow_dispatch: 
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

resolves #530 

# Type of change

*Delete as appropriate:*
- **ci**: Changes to our CI configuration files and scripts (i.e., those in the .github directory)

# Questions (Optional)
- thoughts on the best way to handle the third task — adding documentation / codifying a workflow to update and run the action when a new repo is created?