### PR TITLE
docs: fix broken links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,18 +37,9 @@ plugins:
         imports: [
           "docs/cycle/*",
           "docs/pipeline/*",
-          "docs/experimentalists/pooler/grid/*",
-          "docs/experimentalists/pooler/random/*",
-          "docs/experimentalists/sampler/random/*",
+          "docs/experimentalists/grid/*",
+          "docs/experimentalists/random/*",
           "src/",
-        ]
-      - name: falsification
-        import_url: "https://github.com/autoresearch/autora-experimentalist-falsification/?branch=main"
-        imports: [
-          "docs/*",
-          "docs/sampler/*",
-          "docs/pooler/*",
-          "src/"
         ]
       - name: user-cookiecutter
         import_url: "https://github.com/autoresearch/autora-user-cookiecutter/?branch=main"
@@ -71,26 +62,30 @@ plugins:
         import_url: "https://github.com/autoresearch/autora-theorist-bms/?branch=main"
         imports: [ "src/" ]
       - name: novelty
-        import_url: "https://github.com/autoresearch/autora-experimentalist-sampler-novelty/?branch=main"
+        import_url: "https://github.com/autoresearch/autora-experimentalist-novelty?branch=main"
         imports: [ "src/" ]
       - name: inequality
-        import_url: "https://github.com/autoresearch/autora-experimentalist-sampler-inequality/?branch=main"
+        import_url: "https://github.com/autoresearch/autora-experimentalist-inequality/?branch=main"
         imports: [ "src/" ]
       - name: nearest-value
-        import_url: "https://github.com/autoresearch/autora-experimentalist-sampler-nearest-value/?branch=main"
+        import_url: "https://github.com/autoresearch/autora-experimentalist-nearest-value/?branch=main"
         imports: [ "src/" ]
       - name: disagreement
-        import_url: "https://github.com/autoresearch/autora-experimentalist-sampler-model-disagreement/?branch=main"
+        import_url: "https://github.com/autoresearch/autora-experimentalist-model-disagreement/?branch=main"
         imports: [ "src/" ]
       - name: uncertainty
-        import_url: "https://github.com/autoresearch/autora-experimentalist-sampler-uncertainty/?branch=main"
+        import_url: "https://github.com/autoresearch/autora-experimentalist-uncertainty/?branch=main"
         imports: [ "src/" ]
       - name: leverage
-        import_url: "https://github.com/autoresearch/autora-experimentalist-sampler-leverage/?branch=main"
-        imports: [ "src/" ]  
+        import_url: "https://github.com/autoresearch/autora-experimentalist-leverage/?branch=main"
+        imports: [ "src/" ]
+      - name: falsification
+        import_url: "https://github.com/autoresearch/autora-experimentalist-falsification/?branch=main"
+        imports: [ "src/" ]
       - name: mixture
         import_url: "https://github.com/blinodelka/mixture_experimental_strategies/?branch=main"
         imports: [ "src/" ]
+
   gen-files:
     scripts: [ "mkdocs/generate_code_reference.py" ]
   literate-nav: {}
@@ -183,34 +178,20 @@ nav:
   - Experimentalists:
     - Home: 'experimentalist/index.md'
     - Pipeline: 'core/docs/pipeline/Experimentalist Pipeline Examples.ipynb'
-    - Samplers:
-      - Random:
-          - Home: 'core/docs/experimentalists/sampler/random/index.md'
-          - Quickstart: 'core/docs/experimentalists/sampler/random/quickstart.md'
-      - Novelty: '!import https://github.com/autoresearch/autora-experimentalist-sampler-novelty/?branch=main&extra_imports=["mkdocs/base.yml"]'
-      - Inequality: '!import https://github.com/autoresearch/autora-experimentalist-sampler-inequality/?branch=main&extra_imports=["mkdocs/base.yml"]'
-      - Nearest Value: '!import https://github.com/autoresearch/autora-experimentalist-sampler-nearest-value/?branch=main&extra_imports=["mkdocs/base.yml"]'
-      - Model Disagreement: '!import https://github.com/autoresearch/autora-experimentalist-sampler-model-disagreement/?branch=main&extra_imports=["mkdocs/base.yml"]'
-      - Uncertainty: '!import https://github.com/autoresearch/autora-experimentalist-sampler-uncertainty/?branch=main&extra_imports=["mkdocs/base.yml"]'
-      - Leverage: '!import https://github.com/autoresearch/autora-experimentalist-sampler-leverage/?branch=main&extra_imports=["mkdocs/base.yml"]'
-      - Falsification:
-        - Home: 'falsification/docs/sampler/index.md'
-        - Quickstart: 'falsification/docs/sampler/quickstart.md'
-        - Examples:
-          - Basic Usage: 'falsification/docs/sampler/Basic Usage.ipynb'
-      - Mixture: '!import https://github.com/blinodelka/mixture_experimental_strategies/?branch=main&extra_imports=["mkdocs/base.yml"]'
-    - Poolers:
-      - Grid:
-          - Home: 'core/docs/experimentalists/pooler/grid/index.md'
-          - Quickstart: 'core/docs/experimentalists/pooler/grid/quickstart.md'
-      - Random:
-          - Home: 'core/docs/experimentalists/pooler/random/index.md'
-          - Quickstart: 'core/docs/experimentalists/pooler/random/quickstart.md'
-      - Falsification:
-        - Home: 'falsification/docs/pooler/index.md'
-        - Quickstart: 'falsification/docs/pooler/quickstart.md'
-        - Examples:
-          - Basic Usage: 'falsification/docs/pooler/Basic Usage.ipynb'
+    - Random:
+      - Home: 'core/docs/experimentalists/random/index.md'
+      - Quickstart: 'core/docs/experimentalists/random/quickstart.md'
+    - Grid:
+      - Home: 'core/docs/experimentalists/grid/index.md'
+      - Quickstart: 'core/docs/experimentalists/grid/quickstart.md'
+    - Novelty: '!import https://github.com/autoresearch/autora-experimentalist-novelty/?branch=main&extra_imports=["mkdocs/base.yml"]'
+    - Inequality: '!import https://github.com/autoresearch/autora-experimentalist-inequality/?branch=main&extra_imports=["mkdocs/base.yml"]'
+    - Nearest Value: '!import https://github.com/autoresearch/autora-experimentalist-nearest-value/?branch=main&extra_imports=["mkdocs/base.yml"]'
+    - Model Disagreement: '!import https://github.com/autoresearch/autora-experimentalist-model-disagreement/?branch=main&extra_imports=["mkdocs/base.yml"]'
+    - Uncertainty: '!import https://github.com/autoresearch/autora-experimentalist-uncertainty/?branch=main&extra_imports=["mkdocs/base.yml"]'
+    - Leverage: '!import https://github.com/autoresearch/autora-experimentalist-leverage/?branch=main&extra_imports=["mkdocs/base.yml"]'
+    - Falsification: '!import https://github.com/autoresearch/autora-experimentalist-falsification/?branch=main&extra_imports=["mkdocs/base.yml"]'
+    - Mixture: '!import https://github.com/blinodelka/mixture_experimental_strategies/?branch=main&extra_imports=["mkdocs/base.yml"]'
   - Experiment Runners:
     - Home: 'experiment-runner/index.md'
     - Synthetic: '!import https://github.com/autoresearch/autora-synthetic/?branch=main&extra_imports=["mkdocs/base.yml"]'


### PR DESCRIPTION
# Description

Fix broken links. 

The links were broken since we renamed the experimentalist repositories.

- resolves #574

# Type of change

*Delete as appropriate:*
- **docs**: Documentation only changes

