### PR TITLE
docs: update mkdocs settings to allow copying blocks of code / downloading URL-based snippets

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ theme:
   custom_dir: mkdocs/overrides
   features:
     - navigation.indexes
+    - content.code.copy
 
 plugins:
   multirepo:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,7 +143,7 @@ markdown_extensions:
   pymdownx.superfences: {}
   pymdownx.arithmatex: # required for equation display
     generic: true
-  pymdownx.snippets: {}
+  pymdownx.snippets: { url_download: True }
   pymdownx.tabbed:
     alternate_style: true
 


### PR DESCRIPTION
# Description

Update the documentation:
- Allow copying blocks of code in the browser
- Allow including snippets specified by URL

Required to merge https://github.com/AutoResearch/autora-workflow/pull/44

# Type of change

*Delete as appropriate:*
- **docs**: Documentation only changes

# Screenshots (Optional)
## Copy code blocks

<img width="704" alt="Screenshot 2023-11-29 at 14 18 55" src="https://github.com/AutoResearch/autora/assets/2803227/46cb2ea6-4880-429f-b23b-fec84f5e0bdd">

## Include snippets by URL:
This in the input file:

<img width="1243" alt="Screenshot 2023-11-29 at 14 19 58" src="https://github.com/AutoResearch/autora/assets/2803227/55ade740-0773-4157-80d4-c814dcb25034">

...leads to this in the documentation:

<img width="691" alt="Screenshot 2023-11-29 at 14 20 07" src="https://github.com/AutoResearch/autora/assets/2803227/4f58f2da-a2c0-4d7e-8442-fbd014211e9c">
