### PR TITLE
bugfix: delete workflow from references

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,9 +50,6 @@ plugins:
       - name: workflow-tutorial
         import_url: "https://github.com/autoresearch/autora-workflow/?branch=main"
         imports: ["docs/*"]
-      # - name: workflow
-      #   import_url: "https://github.com/autoresearch/autora-workflow/?branch=main"
-      #   imports: [ "src/" ]
       - name: darts
         import_url: "https://github.com/autoresearch/autora-theorist-darts/?branch=main"
         imports: [ "src/" ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,9 +50,9 @@ plugins:
       - name: workflow-tutorial
         import_url: "https://github.com/autoresearch/autora-workflow/?branch=main"
         imports: ["docs/*"]
-      - name: workflow
-        import_url: "https://github.com/autoresearch/autora-workflow/?branch=main"
-        imports: [ "src/" ]
+      # - name: workflow
+      #   import_url: "https://github.com/autoresearch/autora-workflow/?branch=main"
+      #   imports: [ "src/" ]
       - name: darts
         import_url: "https://github.com/autoresearch/autora-theorist-darts/?branch=main"
         imports: [ "src/" ]
@@ -96,7 +96,7 @@ plugins:
         paths: [
           # from nav_repos above
           "./temp_dir/core/src/",
-          "./temp_dir/workflow/src/",
+          # "./temp_dir/workflow/src/",
           "./temp_dir/darts/src/",
           "./temp_dir/bms/src/",
           "./temp_dir/bsr/src/",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,6 @@ plugins:
         paths: [
           # from nav_repos above
           "./temp_dir/core/src/",
-          # "./temp_dir/workflow/src/",
           "./temp_dir/darts/src/",
           "./temp_dir/bms/src/",
           "./temp_dir/bsr/src/",


### PR DESCRIPTION
# Description

don't import src from workflow!

resolves #589 
 
- **fix**: A bug fix
- **docs**: Documentation only changes
