### PR TITLE
Docs nav fix after 400

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ plugins:
       - name: core
         import_url: "https://github.com/autoresearch/autora-core/?branch=main"
         imports: [
+          "docs/*",
           "docs/cycle/*",
           "docs/pipeline/*",
           "docs/experimentalists/grid/*",
@@ -163,6 +164,12 @@ nav:
     - Online Closed-Loop Discovery: 'user-cookiecutter/docs/index.md'
 - User Guide:
   - Installation: 'installation.md'
+  - Core:
+    - Home: 'core/docs/index.md'
+    - Examples:
+      - 'core/docs/cycle/Basic Introduction to Functions and States.ipynb'
+      - 'core/docs/cycle/Combining Experimentalists with State.ipynb'
+      - 'core/docs/cycle/Linear and Cyclical Workflows using Functions and States.ipynb'
   - Theorists:
     - Home: 'theorist/index.md'
     - DARTS: '!import https://github.com/autoresearch/autora-theorist-darts/?branch=main&extra_imports=["mkdocs/base.yml"]'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,7 +161,8 @@ nav:
   - Advanced:
     - Equation Discovery: 'tutorials/Equation Discovery.ipynb'
     - Experimentalists: 'tutorials/Experimentalist.ipynb'
-    - Online Closed-Loop Discovery: 'user-cookiecutter/docs/index.md'
+    - Online Closed-Loop Discovery: 
+      - 'user-cookiecutter/docs/index.md'
 - User Guide:
   - Installation: 'installation.md'
   - Core:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,7 @@ nav:
       - 'user-cookiecutter/docs/index.md'
 - User Guide:
   - Installation: 'installation.md'
+  - Terminology: 'terminology.md'
   - Core:
     - Home: 'core/docs/index.md'
     - Examples:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,7 +159,7 @@ nav:
     - III - Functional Workflow: 'tutorials/basic/Tutorial-III-Functional-Workflow.ipynb'
     - IV - Customization: 'tutorials/basic/Tutorial-IV-Customization.ipynb'
   - Advanced:
-    - Equation Discovery: 'tutorials/Equation Discovery.ipynb'
+    - Equation Discovery: 'theorist/Equation Discovery.ipynb'
     - Experimentalists: 'tutorials/Experimentalist.ipynb'
     - Online Closed-Loop Discovery: 
       - 'user-cookiecutter/docs/index.md'


### PR DESCRIPTION
# Description

- fix some issues with the existing documentation. 
- add core index and state tutorials from core to user-guide
- add terminology page


We should work on the documentation for core (the index file is currently merely a placeholder)
