### PR TITLE
fix: Updated nav for basic tutorials

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,10 +149,10 @@ nav:
 - Tutorials:
   - Home: 'tutorials/index.md'
   - Basic:
-    - I - Components: 'tutorials/basic/Tutorial-I-Components.ipynb'
-    - II - Loop Constructs: 'tutorials/basic/Tutorial-II-Loop-Constructs.ipynb'
-    - III - Functional Workflow: 'tutorials/basic/Tutorial-III-Functional-Workflow.ipynb'
-    - IV - Customization: 'tutorials/basic/Tutorial-IV-Customization.ipynb'
+    - I - Components: 'tutorials/basic/Tutorial I Components.ipynb'
+    - II - Loop Constructs: 'tutorials/basic/Tutorial II Loop Constructs.ipynb'
+    - III - Functional Workflow: 'tutorials/basic/Tutorial III Functional Workflow.ipynb'
+    - IV - Customization: 'tutorials/basic/Tutorial IV Customization.ipynb'
   - Advanced:
     - Equation Discovery: 'theorist/Equation Discovery.ipynb'
     - Experimentalists: 'tutorials/Experimentalist.ipynb'


### PR DESCRIPTION
# Description

Updated the nav as the basic tutorials were renamed in the last PR.

- resolves #569 

# Type of change
- **fix**: A bug fix

# Remarks (Optional)
- mkdocs serve fails locally, something to do with my path, so my new nav is untested. I'll work on getting it running but the new nav shoooould be fine.
