### PR TITLE
doc: add code references for synthetic runners

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,11 @@ plugins:
           "docs/",
           "src/",
         ]
+      - name: synthetic
+        import_url: "https://github.com/AutoResearch/autora-synthetic/?branch=main"
+        imports: [
+          "src/"
+        ]
       - name: user-cookiecutter
         import_url: "https://github.com/autoresearch/autora-user-cookiecutter/?branch=main"
         imports: [
@@ -98,7 +103,8 @@ plugins:
           "./temp_dir/uncertainty/src/",
           "./temp_dir/leverage/src/",
           "./temp_dir/falsification/src/",
-          "./temp_dir/mixture/src/"
+          "./temp_dir/mixture/src/",
+          "./temp_dir/synthetic/src/"
         ]
         import:
           - https://scikit-learn.org/stable/objects.inv


### PR DESCRIPTION
# Description

add code references for autora-synthetic module (we need eventually should add the optional ones too)

- resolves #603

- **docs**: Documentation only changes

