### PR TITLE
rename experiment_runner to run in abstract equation runner

### DIFF
--- a/docs/tutorials/basic/Tutorial III Functional Workflow.ipynb
+++ b/docs/tutorials/basic/Tutorial III Functional Workflow.ipynb
@@ -327,7 +327,7 @@
     "\n",
     "#### Equation Experiment Method ####\n",
     "sin_experiment = equation_experiment(sp.simplify('sin(x)'), variables.independent_variables, variables.dependent_variables[0])\n",
-    "sin_runner = sin_experiment.experiment_runner\n",
+    "sin_runner = sin_experiment.run\n",
     "\n",
     "experiment_runner = on_state(sin_runner, output=[\"experiment_data\"])"
    ]

--- a/docs/tutorials/basic/Tutorial IV Customization.ipynb
+++ b/docs/tutorials/basic/Tutorial IV Customization.ipynb
@@ -149,7 +149,7 @@
     "\n",
     "#### Define experiment runner and wrap with state functionality ####\n",
     "sin_experiment = equation_experiment(sp.simplify('sin(x)'), variables.independent_variables, variables.dependent_variables[0])\n",
-    "sin_runner = sin_experiment.experiment_runner\n",
+    "sin_runner = sin_experiment.run\n",
     "\n",
     "experiment_runner = on_state(sin_runner, output=[\"experiment_data\"])\n",
     "\n",


### PR DESCRIPTION
# Description

Rename `experiment_runner` function in abstract equation runner to `run`.
See: 
 - https://github.com/AutoResearch/autora-synthetic-abstract-equation/pull/4
 
(if reviewing this, please aprove, merge and release https://github.com/AutoResearch/autora-synthetic-abstract-equation/pull/4 first)

docs only change. no need for a new release of autora parent

