### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,6 +190,7 @@ nav:
     - Examples:
       - 'core/docs/cycle/Basic Introduction to Functions and States.ipynb'
       - 'core/docs/cycle/Combining Experimentalists with State.ipynb'
+      - 'core/docs/cycle/Dynamically Extending and Altering the State.ipynb'
       - 'core/docs/cycle/Linear and Cyclical Workflows using Functions and States.ipynb'
   - Theorists:
     - Home: 'theorist/index.md'


### PR DESCRIPTION
add tutorial on how to extend the state

resolves #645 

- **docs**: Documentation only changes

# Remarks (Optional)
- our documentation is very rich, but some things might be hard to find. A possible fix is to add references in the tutorials to other references. 

- I also think "Examples" is not the right term here. These are more "Tutorials" then examples in my opinion

