### PR TITLE
docs: fixed links in basic tutorial notebooks

### DIFF
--- a/docs/tutorials/basic/Tutorial Ia Theorists.ipynb
+++ b/docs/tutorials/basic/Tutorial Ia Theorists.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Basic Tutorial Ib: Theorists \n",
     "\n",
-    "[Theorists](../../theorist) are classes designed to automate the construction of interpretable models from data. AutoRA theorists are implemented as sklearn regressors and can be used with the `fit` and `predict` methods.\n",
+    "[Theorists](https://autoresearch.github.io/autora/theorist/) are classes designed to automate the construction of interpretable models from data. AutoRA theorists are implemented as sklearn regressors and can be used with the `fit` and `predict` methods.\n",
     "\n",
     "<img src=\"https://autoresearch.github.io/autora/img/theorist.png\" width=\"75%\" alt=\"Theorist Overview\">\n",
     "\n",

--- a/docs/tutorials/basic/Tutorial Ib Experimentalists.ipynb
+++ b/docs/tutorials/basic/Tutorial Ib Experimentalists.ipynb
@@ -11,9 +11,9 @@
    "source": [
     "# Basic Tutorial Ib: Experimentalists\n",
     "\n",
-    "[Experimentalists](../../experimentalist/) are functions designed to return novel experimental conditions that yield scientific merit.\n",
+    "[Experimentalists](https://autoresearch.github.io/autora/experimentalist/) are functions designed to return novel experimental conditions that yield scientific merit.\n",
     "\n",
-    "![Experimentalist](attachment:experimentalist.png)\n",
+    "![Experimentalist](https://autoresearch.github.io/autora/img/experimentalist.png)\n",
     "\n",
     "Experimentalists may use information about candidate models $M$ obtained from a theorist,\n",
     "experiment conditions that have already been probed $\\vec{x}' \\in X'$, or\n",


### PR DESCRIPTION
# Description

Fixed non-local hyperlinks in the basic tutorials notebooks.

- **docs**: Documentation only changes
