### PR TITLE
docs: fixed links and added sudo hints

### DIFF
--- a/docs/examples/closed-loop-bandit-task/init_autora.md
+++ b/docs/examples/closed-loop-bandit-task/init_autora.md
@@ -37,7 +37,7 @@ The AutoRA workflow (specifically the `autora-firebase-runner` and `autora-proli
 - Click on ``Service accounts``.
 ![service_account.png](../img/service_account.png)
 - Having ``Node.js`` selected, click ``Generate a new private key``. This should generate a json file that you can download.
-- Open the file `autora_workflow.py` in the `research_hub`-folder and navigate to the part of the code that contains a placeholder for the credentials. It should look like this
+- Open the file `autora_workflow.py` in the `researcher_hub`-folder and navigate to the part of the code that contains a placeholder for the credentials. It should look like this
 ```python
 firebase_credentials = {
     "type": "type",

--- a/docs/examples/closed-loop-bandit-task/setup.md
+++ b/docs/examples/closed-loop-bandit-task/setup.md
@@ -7,7 +7,7 @@ First, we need to set up our local AutoRA project.
 ## Create Repository
 To ease the setup process for this example, we provide a template repository that contains all the necessary files and configurations. 
 
-Simply visit the following repository on GitHub: https://github.com/AutoResearch/autora-closed-loop-firebase-prolific-bandit-task
+Simply visit the following repository on GitHub: [https://github.com/AutoResearch/autora-closed-loop-firebase-prolific-bandit-task](https://github.com/AutoResearch/autora-closed-loop-firebase-prolific-bandit-task)
 
 Next, click on the green "Use this template" button to create a new repository in your account.
 ![use_template.png](../img/use_template.png)
@@ -75,6 +75,9 @@ npm install -g firebase-tools
 
 We will use this package to deploy our firebase functions for storing data.
 
+!!! hint
+    If you encounter any issues with the installation, make sure that you have the necessary permissions to install packages on your system. You may need to run the commands with `sudo` or as an administrator.
+
 ## Set Up Project Folder with Coockiecutter
 
 To establish an online closed-loop for AutoRA, there are two key components that need to be configured:
@@ -119,6 +122,9 @@ python -m cookiecutter https://github.com/AutoResearch/autora-user-cookiecutter
 You should now have the following project structure:
 
 ![project_structure.png](../img/project_structure.png)
+
+!!! hint
+    If you encounter any issues with the cookiecutter setup, make sure that you have the necessary permissions to install packages on your system. You may need to run the commands with `sudo` or as an administrator.
 
 [Next: Set up Firebase to host our experiment.](firebase.md)
 

--- a/docs/examples/closed-loop-bandit-task/testingzone.md
+++ b/docs/examples/closed-loop-bandit-task/testingzone.md
@@ -77,7 +77,7 @@ firebase init
   9. Don't overwrite the index.html file if the question pops up.
 
 ## Install jsPsych
-- Next, we install jsPsych (still within the testing_zone folder):
+- Next, we install jsPsych (still within the ``testing_zone`` folder):
 ```shell
 npm install jspsych@7.3.1
 ```

--- a/docs/examples/closed-loop-basic/init_autora.md
+++ b/docs/examples/closed-loop-basic/init_autora.md
@@ -33,7 +33,7 @@ The AutoRA workflow (specifically the `autora-firebase-runner`) will need access
 - Click on ``Service accounts``.
 ![service_account.png](../img/service_account.png)
 - Having ``Node.js`` selected, click ``Generate a new private key``. This should generate a json file that you can download.
-- Open the file `autora_workflow.py` in the `research_hub`-folder and navigate to the part of the code that contains a placeholder for the credentials. It should look like this
+- Open the file `autora_workflow.py` in the `researcher_hub`-folder and navigate to the part of the code that contains a placeholder for the credentials. It should look like this
 ```python
 firebase_credentials = {
     "type": "type",

--- a/docs/examples/closed-loop-basic/setup.md
+++ b/docs/examples/closed-loop-basic/setup.md
@@ -77,6 +77,9 @@ npm install -g firebase-tools
 
 We will use this package to deploy our firebase functions for storing data.
 
+!!! hint
+    If you encounter any issues with the installation, make sure that you have the necessary permissions to install packages on your system. You may need to run the commands with `sudo` or as an administrator.
+
 ## Set Up Project Folder with Coockiecutter
 
 To establish an online closed-loop for AutoRA, there are two key components that need to be configured:
@@ -121,6 +124,9 @@ python -m cookiecutter https://github.com/AutoResearch/autora-user-cookiecutter
 - Confirm that you have the following project folders:
 
 ![project_structure.png](../img/project_structure.png)
+
+!!! hint
+    If you encounter any issues with the cookiecutter setup, make sure that you have the necessary permissions to install packages on your system. You may need to run the commands with `sudo` or as an administrator.
 
 ## Next Steps
 

--- a/docs/examples/closed-loop-basic/testingzone.md
+++ b/docs/examples/closed-loop-basic/testingzone.md
@@ -81,7 +81,7 @@ firebase init
   9. Don't overwrite the index.html file if the question pops up.
 
 ## Install jspsych
-- Next, we install jspsych (still within the testing_zone folder):
+- Next, we install jspsych (still within the ``testing_zone`` folder):
 ```shell
 npm install jspsych@7.3.1
 ```


### PR DESCRIPTION
# Description

- Fixed a github repo link in the doc
- Added sudo hints for installing firebase and setting up the cookiecutter template. I encountered an installation issue on a local setup but running the same commands with sudo fixed it.

# Type of change
- **docs**: Documentation only changes

