### PR TITLE
docs: fixed missing import statement in notebooks

### DIFF
--- a/docs/examples/closed-loop-basic/notebooks/sweetbean.ipynb
+++ b/docs/examples/closed-loop-basic/notebooks/sweetbean.ipynb
@@ -10,7 +10,7 @@
     "- a fixation cross is displayed for 1500 ms\n",
     "- a set of two dot stimuli is displayed, one on the left and one on the right for 200ms. Each set contains a certain number of dots and the participant has to indicate whether the numbers of dots in the two sets are the same or different by pressing `y` or `n`.\n",
     "\n",
-    "You can find more in-depth tutorials on automated web experiment generation at the [SweetBean Website](https://autoresearch.github.io/sweetbean/).\n",
+    "You can find more in-depth tutorials on automated web experiment generation at the [SweetBean Website](https://autoresearch.github.io/sweetbean/)).\n",
     "\n"
    ]
   },
@@ -116,6 +116,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from sweetbean.sequence import Block\n",
+    "\n",
     "# create a list of instruction stimuli for the instruction block\n",
     "introduction_list = [introduction_welcome,\n",
     "                      introduction_pictures,\n",
@@ -222,7 +224,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the dot stimulus is shown for 2000ms (``duration=2000``). It consists of two set of dots (``number_of_apertures=2``), which are parameterized by the two timeline variables ``number_of_oobs=[dot_stimulus_left, dot_stimulus_right]``. Finally, we allow participants to record a response on each stimulus, indicating whether the dots match or not by pressing the respective keys for `y` and `n` (``choices=[\"y\", \"n\"]``)"
+    "Note that the dot stimulus is shown for 2000ms (``duration=2000``). It consits of two set of dots (``number_of_apertures=2``), which are parameterized by the two timeline variables ``number_of_oobs=[dot_stimulus_left, dot_stimulus_right]``. Finally, we allow participants to record a response on each stimulus, indicating whether the dots match or not by pressing the respective keys for `y` and `n` (``choices=[\"y\", \"n\"]``)"
    ]
   },
   {
@@ -255,7 +257,7 @@
    "source": [
     "## Experiment Block Sequence\n",
     "\n",
-    "Now that we have specified all of our experiment blocks, we put them together into an experiment. The function below compiles the experiment and converts it into a html file."
+    "Now that we have specified all of our experiment blocks, we put them together into an experiment. The function below compiles the experiment and converts it into an html file."
    ]
   },
   {
@@ -272,7 +274,7 @@
     "# define the entire experiment\n",
     "experiment = Experiment([instruction_block, task_block, exit_block])\n",
     "\n",
-    "# export experiment to html file\n",
+    "# export expeirment to html file\n",
     "experiment.to_html(\"psychophysics_experiment.html\")"
    ]
   },
@@ -289,7 +291,7 @@
    "source": [
     "## Writing a Function to Automate the Generation of Stimulus Sequences\n",
     "\n",
-    "The function below compiles the code above into a single function, and returns a web-based (JavaScript) experiment, written in ``jsPsych``.\n",
+    "The function below compiles the code above into a single function, and returns a web-based (java script) experiment, written in ``jsPsych``.\n",
     "\n",
     "The function takes a timeline, containing a sequence of trials, as input, along with the two levels for the dot stimuli."
    ]
@@ -386,8 +388,7 @@
  ],
  "metadata": {
   "colab": {
-   "provenance": [],
-   "toc_visible": true
+   "provenance": []
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/docs/examples/closed-loop-basic/notebooks/sweetbean.ipynb
+++ b/docs/examples/closed-loop-basic/notebooks/sweetbean.ipynb
@@ -10,7 +10,7 @@
     "- a fixation cross is displayed for 1500 ms\n",
     "- a set of two dot stimuli is displayed, one on the left and one on the right for 200ms. Each set contains a certain number of dots and the participant has to indicate whether the numbers of dots in the two sets are the same or different by pressing `y` or `n`.\n",
     "\n",
-    "You can find more in-depth tutorials on automated web experiment generation at the [SweetBean Website](https://autoresearch.github.io/sweetbean/)).\n",
+    "You can find more in-depth tutorials on automated web experiment generation at the [SweetBean Website](https://autoresearch.github.io/sweetbean/).\n",
     "\n"
    ]
   },
@@ -224,7 +224,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the dot stimulus is shown for 2000ms (``duration=2000``). It consits of two set of dots (``number_of_apertures=2``), which are parameterized by the two timeline variables ``number_of_oobs=[dot_stimulus_left, dot_stimulus_right]``. Finally, we allow participants to record a response on each stimulus, indicating whether the dots match or not by pressing the respective keys for `y` and `n` (``choices=[\"y\", \"n\"]``)"
+    "Note that the dot stimulus is shown for 2000ms (``duration=2000``). It consists of two set of dots (``number_of_apertures=2``), which are parameterized by the two timeline variables ``number_of_oobs=[dot_stimulus_left, dot_stimulus_right]``. Finally, we allow participants to record a response on each stimulus, indicating whether the dots match or not by pressing the respective keys for `y` and `n` (``choices=[\"y\", \"n\"]``)"
    ]
   },
   {
@@ -274,7 +274,7 @@
     "# define the entire experiment\n",
     "experiment = Experiment([instruction_block, task_block, exit_block])\n",
     "\n",
-    "# export expeirment to html file\n",
+    "# export experiment to html file\n",
     "experiment.to_html(\"psychophysics_experiment.html\")"
    ]
   },
@@ -291,7 +291,7 @@
    "source": [
     "## Writing a Function to Automate the Generation of Stimulus Sequences\n",
     "\n",
-    "The function below compiles the code above into a single function, and returns a web-based (java script) experiment, written in ``jsPsych``.\n",
+    "The function below compiles the code above into a single function, and returns a web-based (JavaScript) experiment, written in ``jsPsych``.\n",
     "\n",
     "The function takes a timeline, containing a sequence of trials, as input, along with the two levels for the dot stimuli."
    ]


### PR DESCRIPTION
# Description

Fixes a missing import statement in the sweetbean notebook from the closed-loop example. 

# Type of change
- **docs**: Documentation only changes