### PR TITLE
doc: fixed typos in sweetbean notebook

### DIFF
--- a/docs/examples/closed-loop-basic/notebooks/sweetbean.ipynb
+++ b/docs/examples/closed-loop-basic/notebooks/sweetbean.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Generating Stimulus Sequences for a Closed-Loop Psychophysics Study\n",
     "\n",
-    "In this example, we use SweetPea to generate an experimental sequence for a same-different Psychophysics experiment. In this experiment, each trials has the following sequence of events:\n",
+    "In this example, we use SweetBean to generate an experimental sequence for a same-different Psychophysics experiment. In this experiment, each trials has the following sequence of events:\n",
     "- a fixation cross is displayed for 1500 ms\n",
     "- a set of two dot stimuli is displayed, one on the left and one on the right for 200ms. Each set contains a certain number of dots and the participant has to indicate whether the numbers of dots in the two sets are the same or different by pressing `y` or `n`.\n",
     "\n",
@@ -64,9 +64,9 @@
    "source": [
     "## Instruction Block\n",
     "\n",
-    "Many experiment require instructions that tell the participants what to do.\n",
+    "Many experiments require instructions that tell the participants what to do.\n",
     "\n",
-    "Creating instructions in SweetPea is quite simple. First, we define a number of text stimuli that the participant sees. Then, we specify the order of the text stimuli within a block of instructions."
+    "Creating instructions in SweetBean is quite simple. First, we define a number of text stimuli that the participant sees. Then, we specify the order of the text stimuli within a block of instructions."
    ]
   },
   {


### PR DESCRIPTION
# Description

- fixed minor typos (e.g., "SweetPea" -> "SweetBean") in sweetbean notebook as part of the psychophysics tutorial. 


# Type of change
- **docs**: Documentation only changes

